### PR TITLE
feat(boot): expose specification repository extension points

### DIFF
--- a/README.md
+++ b/README.md
@@ -562,10 +562,6 @@ class SpecificationRepositoryCustomization {
         };
     }
 
-    @Bean
-    SpecificationRepositoryCustomizer specificationRepositoryCustomizer() {
-        return builder -> builder.addOperatorHandler(jsonbEqualsOperator());
-    }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -536,6 +536,45 @@ ValueConverter uuidConverter = new ValueConverter() {
 
 Extend `SpecificationRepositoryImpl` and override the `QueryPlanSpecificationFactory` with your own `OperatorRegistry`, `ValueConversionService`, and `PathResolver`.
 
+### Spring Boot Customization
+
+When you use the Boot 3 or Boot 4 starter, the extension points are exposed as beans:
+
+- register `OperatorHandler` beans to add or replace operators
+- register `ValueConverter` beans to customize value conversion
+- register `SpecificationRepositoryCustomizer` beans to adjust the repository pipeline
+- optionally provide `PathResolver`, `ConversionService`, `QueryPlanSpecificationFactory`, or a full `SpecificationRepositoryConfiguration` bean
+
+```java
+@Configuration(proxyBeanMethods = false)
+class SpecificationRepositoryCustomization {
+
+    @Bean
+    OperatorHandler jsonbEqualsOperator() {
+        return new OperatorHandler() {
+            @Override public FilterOperator operator() {
+                return Operators.custom("jsonb_eq");
+            }
+
+            @Override public Predicate create(OperatorContext context) {
+                return context.criteriaBuilder().isNotNull(context.path());
+            }
+        };
+    }
+
+    @Bean
+    SpecificationRepositoryCustomizer specificationRepositoryCustomizer() {
+        return builder -> builder.addOperatorHandler(jsonbEqualsOperator());
+    }
+}
+```
+
+Important notes:
+
+- custom `OperatorHandler` beans are registered after the defaults, so they can replace a built-in operator cleanly
+- custom `ValueConverter` beans are registered before the defaults, so domain-specific conversion can win first
+- providing a `SpecificationRepositoryConfiguration` bean replaces the starter-assembled configuration entirely
+
 ## Demo Applications
 
 The repository includes four demo applications:
@@ -576,7 +615,11 @@ Dependency management is aligned with the Spring Boot BOM -- no explicit version
 The starters auto-configure JPA repository scanning from the application's auto-configuration
 packages and register `SpecificationRepositoryImpl` as the repository base class. Manual
 configuration via `@EnableSpecificationRepositories` or `@EnableJpaRepositories` is still
-available when you do not want to use the starters.
+available when you do not want to use the starters. The starters also contribute a
+`SpecificationRepositoryConfiguration` bean so operator handlers, value converters, and
+repository customizers can be wired through standard Spring beans. `@EnableSpecificationRepositories`
+uses the same repository factory bean, so the same configuration bean can also be supplied in
+manual Spring setups.
 
 ## Building
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -4,7 +4,7 @@ The project is split into a pure query core and JPA/Spring adapters.
 
 - `specification-repository-core` contains the immutable query plan and fluent builder.
 - `specification-repository-jpa` translates the query plan into Spring Data JPA `Specification` objects and manages join/fetch reuse through a metamodel-driven registry.
-- Starter modules expose auto-configuration for Spring Boot 3 and 4.
+- Starter modules expose auto-configuration for Spring Boot 3 and 4, including bean-based extension points for operators, value converters, and repository customization.
 
 All library code lives under the `com.borjaglez.specrepository` package hierarchy.
 

--- a/docs/extensibility.md
+++ b/docs/extensibility.md
@@ -4,6 +4,7 @@ The library is designed around extension contracts in the `com.borjaglez.specrep
 
 - `OperatorHandler`: add or replace operators.
 - `ValueConverter`: override value parsing for custom types.
+- `SpecificationRepositoryCustomizer`: adjust the repository pipeline built by the Spring Boot starters.
 - `SpecificationRepository`: use the fluent DSL or execute an externally built `QueryPlan`.
 
 Example custom operator use cases:
@@ -11,3 +12,12 @@ Example custom operator use cases:
 - PostgreSQL JSONB comparisons
 - case-insensitive locale-specific matching
 - tenant-aware predicates
+
+## Spring Boot starters
+
+The Boot 3 and Boot 4 starters expose extensibility through beans:
+
+- `OperatorHandler` beans are appended after the defaults, so custom handlers can replace the built-in operator for the same `FilterOperator`.
+- `ValueConverter` beans are applied before the defaults, so domain-specific converters can override standard parsing.
+- `SpecificationRepositoryCustomizer` beans can tweak the `SpecificationRepositoryConfiguration.Builder` before the final repository pipeline is created.
+- Advanced scenarios can provide `PathResolver`, `ConversionService`, `QueryPlanSpecificationFactory`, or a full `SpecificationRepositoryConfiguration` bean.

--- a/specification-repository-boot3-starter/build.gradle.kts
+++ b/specification-repository-boot3-starter/build.gradle.kts
@@ -10,6 +10,8 @@ dependencies {
     api(project(":specification-repository-jpa"))
     api(libs.spring.boot.autoconfigure)
     annotationProcessor(libs.spring.boot.configuration.processor)
+    testImplementation(libs.spring.boot3.starter.data.jpa)
     testImplementation(libs.spring.data.jpa)
     testImplementation(libs.spring.boot.starter.test)
+    testImplementation(libs.h2)
 }

--- a/specification-repository-boot3-starter/src/main/java/com/borjaglez/specrepository/boot3/SpecificationRepositoryAutoConfiguration.java
+++ b/specification-repository-boot3-starter/src/main/java/com/borjaglez/specrepository/boot3/SpecificationRepositoryAutoConfiguration.java
@@ -5,6 +5,7 @@ import java.util.Locale;
 
 import javax.sql.DataSource;
 
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBooleanProperty;
@@ -14,7 +15,9 @@ import org.springframework.boot.autoconfigure.data.AbstractRepositoryConfigurati
 import org.springframework.boot.autoconfigure.data.jpa.JpaRepositoriesAutoConfiguration;
 import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
 import org.springframework.boot.autoconfigure.task.TaskExecutionAutoConfiguration;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
+import org.springframework.core.convert.ConversionService;
 import org.springframework.core.env.Environment;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
@@ -24,7 +27,14 @@ import org.springframework.data.repository.config.BootstrapMode;
 import org.springframework.data.repository.config.RepositoryConfigurationExtension;
 import org.springframework.util.StringUtils;
 
+import com.borjaglez.specrepository.jpa.SpecificationRepositoryFactoryBean;
 import com.borjaglez.specrepository.jpa.SpecificationRepositoryImpl;
+import com.borjaglez.specrepository.jpa.spi.OperatorHandler;
+import com.borjaglez.specrepository.jpa.spi.SpecificationRepositoryCustomizer;
+import com.borjaglez.specrepository.jpa.spi.ValueConverter;
+import com.borjaglez.specrepository.jpa.support.PathResolver;
+import com.borjaglez.specrepository.jpa.support.QueryPlanSpecificationFactory;
+import com.borjaglez.specrepository.jpa.support.SpecificationRepositoryConfiguration;
 
 @AutoConfiguration(
     before = JpaRepositoriesAutoConfiguration.class,
@@ -34,7 +44,29 @@ import com.borjaglez.specrepository.jpa.SpecificationRepositoryImpl;
 @ConditionalOnMissingBean({JpaRepositoryFactoryBean.class, JpaRepositoryConfigExtension.class})
 @ConditionalOnBooleanProperty(name = "spring.data.jpa.repositories.enabled", matchIfMissing = true)
 @Import(SpecificationJpaRepositoriesRegistrar.class)
-public class SpecificationRepositoryAutoConfiguration {}
+public class SpecificationRepositoryAutoConfiguration {
+
+  @Bean
+  @ConditionalOnMissingBean
+  SpecificationRepositoryConfiguration specificationRepositoryConfiguration(
+      ObjectProvider<OperatorHandler> operatorHandlers,
+      ObjectProvider<ValueConverter> valueConverters,
+      ObjectProvider<SpecificationRepositoryCustomizer> customizers,
+      ObjectProvider<ConversionService> conversionServices,
+      ObjectProvider<PathResolver> pathResolvers,
+      ObjectProvider<QueryPlanSpecificationFactory> specificationFactories) {
+    SpecificationRepositoryConfiguration.Builder builder =
+        SpecificationRepositoryConfiguration.builder();
+    valueConverters.orderedStream().forEach(builder::addValueConverter);
+    builder.addDefaultValueConverters().addDefaultOperatorHandlers();
+    operatorHandlers.orderedStream().forEach(builder::addOperatorHandler);
+    conversionServices.ifAvailable(builder::conversionService);
+    pathResolvers.ifAvailable(builder::pathResolver);
+    specificationFactories.ifAvailable(builder::specificationFactory);
+    customizers.orderedStream().forEach(customizer -> customizer.customize(builder));
+    return builder.build();
+  }
+}
 
 final class SpecificationJpaRepositoriesRegistrar
     extends AbstractRepositoryConfigurationSourceSupport {
@@ -74,6 +106,8 @@ final class SpecificationJpaRepositoriesRegistrar
     }
   }
 
-  @EnableJpaRepositories(repositoryBaseClass = SpecificationRepositoryImpl.class)
+  @EnableJpaRepositories(
+      repositoryBaseClass = SpecificationRepositoryImpl.class,
+      repositoryFactoryBeanClass = SpecificationRepositoryFactoryBean.class)
   private static final class EnableJpaRepositoriesConfiguration {}
 }

--- a/specification-repository-boot3-starter/src/test/java/com/borjaglez/specrepository/boot3/ExtensionTestApplication.java
+++ b/specification-repository-boot3-starter/src/test/java/com/borjaglez/specrepository/boot3/ExtensionTestApplication.java
@@ -1,0 +1,6 @@
+package com.borjaglez.specrepository.boot3;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class ExtensionTestApplication {}

--- a/specification-repository-boot3-starter/src/test/java/com/borjaglez/specrepository/boot3/ExtensionTestProduct.java
+++ b/specification-repository-boot3-starter/src/test/java/com/borjaglez/specrepository/boot3/ExtensionTestProduct.java
@@ -1,0 +1,34 @@
+package com.borjaglez.specrepository.boot3;
+
+import java.util.UUID;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+
+@Entity
+public class ExtensionTestProduct {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  private String name;
+
+  private UUID externalId;
+
+  public ExtensionTestProduct() {}
+
+  public ExtensionTestProduct(String name, UUID externalId) {
+    this.name = name;
+    this.externalId = externalId;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public UUID getExternalId() {
+    return externalId;
+  }
+}

--- a/specification-repository-boot3-starter/src/test/java/com/borjaglez/specrepository/boot3/ExtensionTestProductRepository.java
+++ b/specification-repository-boot3-starter/src/test/java/com/borjaglez/specrepository/boot3/ExtensionTestProductRepository.java
@@ -1,0 +1,6 @@
+package com.borjaglez.specrepository.boot3;
+
+import com.borjaglez.specrepository.jpa.SpecificationRepository;
+
+public interface ExtensionTestProductRepository
+    extends SpecificationRepository<ExtensionTestProduct, Long> {}

--- a/specification-repository-boot3-starter/src/test/java/com/borjaglez/specrepository/boot3/SpecificationRepositoryAutoConfigurationIntegrationTest.java
+++ b/specification-repository-boot3-starter/src/test/java/com/borjaglez/specrepository/boot3/SpecificationRepositoryAutoConfigurationIntegrationTest.java
@@ -1,0 +1,96 @@
+package com.borjaglez.specrepository.boot3;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.UUID;
+
+import jakarta.persistence.criteria.Predicate;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.borjaglez.specrepository.core.FilterOperator;
+import com.borjaglez.specrepository.core.Operators;
+import com.borjaglez.specrepository.jpa.spi.OperatorContext;
+import com.borjaglez.specrepository.jpa.spi.OperatorHandler;
+import com.borjaglez.specrepository.jpa.spi.ValueConverter;
+
+@SpringBootTest(
+    classes = {
+      ExtensionTestApplication.class,
+      SpecificationRepositoryAutoConfigurationIntegrationTest.CustomizationConfiguration.class
+    },
+    properties = {
+      "spring.datasource.url=jdbc:h2:mem:boot3-extension-test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE",
+      "spring.datasource.driver-class-name=org.h2.Driver",
+      "spring.jpa.hibernate.ddl-auto=create-drop"
+    })
+class SpecificationRepositoryAutoConfigurationIntegrationTest {
+  private static final FilterOperator CUSTOM_EQUALS = Operators.custom("custom_equals");
+
+  @Autowired private ExtensionTestProductRepository repository;
+
+  private UUID externalId;
+
+  @BeforeEach
+  void setUp() {
+    repository.deleteAll();
+    externalId = UUID.randomUUID();
+    repository.save(new ExtensionTestProduct("alpha", externalId));
+    repository.save(new ExtensionTestProduct("beta", UUID.randomUUID()));
+  }
+
+  @Test
+  void shouldApplyCustomOperatorHandlerBeans() {
+    List<ExtensionTestProduct> results =
+        repository.query().where("name", CUSTOM_EQUALS, "alpha").findAll();
+
+    assertThat(results).extracting(ExtensionTestProduct::getName).containsExactly("alpha");
+  }
+
+  @Test
+  void shouldApplyCustomValueConverterBeans() {
+    List<ExtensionTestProduct> results =
+        repository.query().where("externalId", Operators.EQUALS, externalId.toString()).findAll();
+
+    assertThat(results).extracting(ExtensionTestProduct::getExternalId).containsExactly(externalId);
+  }
+
+  @Configuration(proxyBeanMethods = false)
+  static class CustomizationConfiguration {
+    @Bean
+    OperatorHandler customEqualsOperatorHandler() {
+      return new OperatorHandler() {
+        @Override
+        public FilterOperator operator() {
+          return CUSTOM_EQUALS;
+        }
+
+        @Override
+        public Predicate create(OperatorContext context) {
+          return context.criteriaBuilder().equal(context.path(), context.value());
+        }
+      };
+    }
+
+    @Bean
+    ValueConverter uuidStringValueConverter() {
+      return new ValueConverter() {
+        @Override
+        public boolean supports(Class<?> targetType, FilterOperator operator) {
+          return UUID.class.isAssignableFrom(targetType);
+        }
+
+        @Override
+        public Object convert(Object value, Class<?> targetType, FilterOperator operator) {
+          return value instanceof String stringValue ? UUID.fromString(stringValue) : value;
+        }
+      };
+    }
+  }
+}

--- a/specification-repository-boot3-starter/src/test/java/com/borjaglez/specrepository/boot3/SpecificationRepositoryAutoConfigurationTest.java
+++ b/specification-repository-boot3-starter/src/test/java/com/borjaglez/specrepository/boot3/SpecificationRepositoryAutoConfigurationTest.java
@@ -1,16 +1,25 @@
 package com.borjaglez.specrepository.boot3;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.context.annotation.Import;
+import org.springframework.context.support.GenericApplicationContext;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.data.jpa.repository.config.JpaRepositoryConfigExtension;
 import org.springframework.data.repository.config.BootstrapMode;
 import org.springframework.mock.env.MockEnvironment;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import com.borjaglez.specrepository.core.Operators;
+import com.borjaglez.specrepository.jpa.SpecificationRepositoryFactoryBean;
 import com.borjaglez.specrepository.jpa.SpecificationRepositoryImpl;
+import com.borjaglez.specrepository.jpa.spi.OperatorHandler;
+import com.borjaglez.specrepository.jpa.spi.SpecificationRepositoryCustomizer;
+import com.borjaglez.specrepository.jpa.spi.ValueConverter;
+import com.borjaglez.specrepository.jpa.support.PathResolver;
+import com.borjaglez.specrepository.jpa.support.SpecificationRepositoryConfiguration;
 
 class SpecificationRepositoryAutoConfigurationTest {
 
@@ -40,6 +49,46 @@ class SpecificationRepositoryAutoConfigurationTest {
 
     assertThat(annotation).isNotNull();
     assertThat(annotation.repositoryBaseClass()).isEqualTo(SpecificationRepositoryImpl.class);
+    assertThat(annotation.repositoryFactoryBeanClass())
+        .isEqualTo(SpecificationRepositoryFactoryBean.class);
+  }
+
+  @Test
+  void shouldExposeExtensionPointsThroughConfigurationBean() {
+    GenericApplicationContext context = new GenericApplicationContext();
+    context.registerBean(
+        "customOperatorHandler", OperatorHandler.class, this::customOperatorHandler);
+    context.registerBean("customValueConverter", ValueConverter.class, this::customValueConverter);
+    context.registerBean("customPathResolver", PathResolver.class, PathResolver::new);
+    context.registerBean(
+        "specificationRepositoryCustomizer",
+        SpecificationRepositoryCustomizer.class,
+        () ->
+            builder ->
+                builder
+                    .pathResolver(context.getBean("customPathResolver", PathResolver.class))
+                    .clearValueConverters()
+                    .addValueConverter(
+                        context.getBean("customValueConverter", ValueConverter.class)));
+    context.refresh();
+
+    SpecificationRepositoryConfiguration configuration =
+        new SpecificationRepositoryAutoConfiguration()
+            .specificationRepositoryConfiguration(
+                context.getBeanProvider(OperatorHandler.class),
+                context.getBeanProvider(ValueConverter.class),
+                context.getBeanProvider(SpecificationRepositoryCustomizer.class),
+                context.getBeanProvider(org.springframework.core.convert.ConversionService.class),
+                context.getBeanProvider(PathResolver.class),
+                context.getBeanProvider(
+                    com.borjaglez.specrepository.jpa.support.QueryPlanSpecificationFactory.class));
+
+    assertThat(configuration.pathResolver())
+        .isSameAs(context.getBean("customPathResolver", PathResolver.class));
+    assertThat(configuration.valueConverters())
+        .containsExactly(context.getBean("customValueConverter", ValueConverter.class));
+    assertThat(configuration.operatorHandlers())
+        .anyMatch(handler -> handler.operator().equals(Operators.custom("jsonb_eq")));
   }
 
   @Test
@@ -79,5 +128,29 @@ class SpecificationRepositoryAutoConfigurationTest {
   private static <T> T invoke(
       SpecificationJpaRepositoriesRegistrar registrar, String methodName, Class<T> resultType) {
     return resultType.cast(ReflectionTestUtils.invokeMethod(registrar, methodName));
+  }
+
+  private OperatorHandler customOperatorHandler() {
+    OperatorHandler operatorHandler = org.mockito.Mockito.mock(OperatorHandler.class);
+    when(operatorHandler.operator()).thenReturn(Operators.custom("jsonb_eq"));
+    return operatorHandler;
+  }
+
+  private ValueConverter customValueConverter() {
+    return new ValueConverter() {
+      @Override
+      public boolean supports(
+          Class<?> targetType, com.borjaglez.specrepository.core.FilterOperator operator) {
+        return true;
+      }
+
+      @Override
+      public Object convert(
+          Object value,
+          Class<?> targetType,
+          com.borjaglez.specrepository.core.FilterOperator operator) {
+        return value;
+      }
+    };
   }
 }

--- a/specification-repository-boot4-starter/build.gradle.kts
+++ b/specification-repository-boot4-starter/build.gradle.kts
@@ -10,6 +10,8 @@ dependencies {
     api(project(":specification-repository-jpa"))
     api(libs.spring.boot.autoconfigure)
     annotationProcessor(libs.spring.boot.configuration.processor)
+    testImplementation(libs.spring.boot4.starter.data.jpa)
     testImplementation(libs.spring.data.jpa)
     testImplementation(libs.spring.boot.starter.test)
+    testImplementation(libs.h2)
 }

--- a/specification-repository-boot4-starter/src/main/java/com/borjaglez/specrepository/boot4/SpecificationRepositoryAutoConfiguration.java
+++ b/specification-repository-boot4-starter/src/main/java/com/borjaglez/specrepository/boot4/SpecificationRepositoryAutoConfiguration.java
@@ -5,6 +5,7 @@ import java.util.Locale;
 
 import javax.sql.DataSource;
 
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBooleanProperty;
@@ -12,7 +13,9 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.data.AbstractRepositoryConfigurationSourceSupport;
 import org.springframework.boot.autoconfigure.task.TaskExecutionAutoConfiguration;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
+import org.springframework.core.convert.ConversionService;
 import org.springframework.core.env.Environment;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
@@ -22,7 +25,14 @@ import org.springframework.data.repository.config.BootstrapMode;
 import org.springframework.data.repository.config.RepositoryConfigurationExtension;
 import org.springframework.util.StringUtils;
 
+import com.borjaglez.specrepository.jpa.SpecificationRepositoryFactoryBean;
 import com.borjaglez.specrepository.jpa.SpecificationRepositoryImpl;
+import com.borjaglez.specrepository.jpa.spi.OperatorHandler;
+import com.borjaglez.specrepository.jpa.spi.SpecificationRepositoryCustomizer;
+import com.borjaglez.specrepository.jpa.spi.ValueConverter;
+import com.borjaglez.specrepository.jpa.support.PathResolver;
+import com.borjaglez.specrepository.jpa.support.QueryPlanSpecificationFactory;
+import com.borjaglez.specrepository.jpa.support.SpecificationRepositoryConfiguration;
 
 @AutoConfiguration(
     beforeName =
@@ -34,7 +44,29 @@ import com.borjaglez.specrepository.jpa.SpecificationRepositoryImpl;
 @ConditionalOnMissingBean({JpaRepositoryFactoryBean.class, JpaRepositoryConfigExtension.class})
 @ConditionalOnBooleanProperty(name = "spring.data.jpa.repositories.enabled", matchIfMissing = true)
 @Import(SpecificationJpaRepositoriesRegistrar.class)
-public class SpecificationRepositoryAutoConfiguration {}
+public class SpecificationRepositoryAutoConfiguration {
+
+  @Bean
+  @ConditionalOnMissingBean
+  SpecificationRepositoryConfiguration specificationRepositoryConfiguration(
+      ObjectProvider<OperatorHandler> operatorHandlers,
+      ObjectProvider<ValueConverter> valueConverters,
+      ObjectProvider<SpecificationRepositoryCustomizer> customizers,
+      ObjectProvider<ConversionService> conversionServices,
+      ObjectProvider<PathResolver> pathResolvers,
+      ObjectProvider<QueryPlanSpecificationFactory> specificationFactories) {
+    SpecificationRepositoryConfiguration.Builder builder =
+        SpecificationRepositoryConfiguration.builder();
+    valueConverters.orderedStream().forEach(builder::addValueConverter);
+    builder.addDefaultValueConverters().addDefaultOperatorHandlers();
+    operatorHandlers.orderedStream().forEach(builder::addOperatorHandler);
+    conversionServices.ifAvailable(builder::conversionService);
+    pathResolvers.ifAvailable(builder::pathResolver);
+    specificationFactories.ifAvailable(builder::specificationFactory);
+    customizers.orderedStream().forEach(customizer -> customizer.customize(builder));
+    return builder.build();
+  }
+}
 
 final class SpecificationJpaRepositoriesRegistrar
     extends AbstractRepositoryConfigurationSourceSupport {
@@ -74,6 +106,8 @@ final class SpecificationJpaRepositoriesRegistrar
     }
   }
 
-  @EnableJpaRepositories(repositoryBaseClass = SpecificationRepositoryImpl.class)
+  @EnableJpaRepositories(
+      repositoryBaseClass = SpecificationRepositoryImpl.class,
+      repositoryFactoryBeanClass = SpecificationRepositoryFactoryBean.class)
   private static final class EnableJpaRepositoriesConfiguration {}
 }

--- a/specification-repository-boot4-starter/src/test/java/com/borjaglez/specrepository/boot4/ExtensionTestApplication.java
+++ b/specification-repository-boot4-starter/src/test/java/com/borjaglez/specrepository/boot4/ExtensionTestApplication.java
@@ -1,0 +1,6 @@
+package com.borjaglez.specrepository.boot4;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class ExtensionTestApplication {}

--- a/specification-repository-boot4-starter/src/test/java/com/borjaglez/specrepository/boot4/ExtensionTestProduct.java
+++ b/specification-repository-boot4-starter/src/test/java/com/borjaglez/specrepository/boot4/ExtensionTestProduct.java
@@ -1,0 +1,34 @@
+package com.borjaglez.specrepository.boot4;
+
+import java.util.UUID;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+
+@Entity
+public class ExtensionTestProduct {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  private String name;
+
+  private UUID externalId;
+
+  public ExtensionTestProduct() {}
+
+  public ExtensionTestProduct(String name, UUID externalId) {
+    this.name = name;
+    this.externalId = externalId;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public UUID getExternalId() {
+    return externalId;
+  }
+}

--- a/specification-repository-boot4-starter/src/test/java/com/borjaglez/specrepository/boot4/ExtensionTestProductRepository.java
+++ b/specification-repository-boot4-starter/src/test/java/com/borjaglez/specrepository/boot4/ExtensionTestProductRepository.java
@@ -1,0 +1,6 @@
+package com.borjaglez.specrepository.boot4;
+
+import com.borjaglez.specrepository.jpa.SpecificationRepository;
+
+public interface ExtensionTestProductRepository
+    extends SpecificationRepository<ExtensionTestProduct, Long> {}

--- a/specification-repository-boot4-starter/src/test/java/com/borjaglez/specrepository/boot4/SpecificationRepositoryAutoConfigurationIntegrationTest.java
+++ b/specification-repository-boot4-starter/src/test/java/com/borjaglez/specrepository/boot4/SpecificationRepositoryAutoConfigurationIntegrationTest.java
@@ -1,0 +1,96 @@
+package com.borjaglez.specrepository.boot4;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.UUID;
+
+import jakarta.persistence.criteria.Predicate;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.borjaglez.specrepository.core.FilterOperator;
+import com.borjaglez.specrepository.core.Operators;
+import com.borjaglez.specrepository.jpa.spi.OperatorContext;
+import com.borjaglez.specrepository.jpa.spi.OperatorHandler;
+import com.borjaglez.specrepository.jpa.spi.ValueConverter;
+
+@SpringBootTest(
+    classes = {
+      ExtensionTestApplication.class,
+      SpecificationRepositoryAutoConfigurationIntegrationTest.CustomizationConfiguration.class
+    },
+    properties = {
+      "spring.datasource.url=jdbc:h2:mem:boot4-extension-test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE",
+      "spring.datasource.driver-class-name=org.h2.Driver",
+      "spring.jpa.hibernate.ddl-auto=create-drop"
+    })
+class SpecificationRepositoryAutoConfigurationIntegrationTest {
+  private static final FilterOperator CUSTOM_EQUALS = Operators.custom("custom_equals");
+
+  @Autowired private ExtensionTestProductRepository repository;
+
+  private UUID externalId;
+
+  @BeforeEach
+  void setUp() {
+    repository.deleteAll();
+    externalId = UUID.randomUUID();
+    repository.save(new ExtensionTestProduct("alpha", externalId));
+    repository.save(new ExtensionTestProduct("beta", UUID.randomUUID()));
+  }
+
+  @Test
+  void shouldApplyCustomOperatorHandlerBeans() {
+    List<ExtensionTestProduct> results =
+        repository.query().where("name", CUSTOM_EQUALS, "alpha").findAll();
+
+    assertThat(results).extracting(ExtensionTestProduct::getName).containsExactly("alpha");
+  }
+
+  @Test
+  void shouldApplyCustomValueConverterBeans() {
+    List<ExtensionTestProduct> results =
+        repository.query().where("externalId", Operators.EQUALS, externalId.toString()).findAll();
+
+    assertThat(results).extracting(ExtensionTestProduct::getExternalId).containsExactly(externalId);
+  }
+
+  @Configuration(proxyBeanMethods = false)
+  static class CustomizationConfiguration {
+    @Bean
+    OperatorHandler customEqualsOperatorHandler() {
+      return new OperatorHandler() {
+        @Override
+        public FilterOperator operator() {
+          return CUSTOM_EQUALS;
+        }
+
+        @Override
+        public Predicate create(OperatorContext context) {
+          return context.criteriaBuilder().equal(context.path(), context.value());
+        }
+      };
+    }
+
+    @Bean
+    ValueConverter uuidStringValueConverter() {
+      return new ValueConverter() {
+        @Override
+        public boolean supports(Class<?> targetType, FilterOperator operator) {
+          return UUID.class.isAssignableFrom(targetType);
+        }
+
+        @Override
+        public Object convert(Object value, Class<?> targetType, FilterOperator operator) {
+          return value instanceof String stringValue ? UUID.fromString(stringValue) : value;
+        }
+      };
+    }
+  }
+}

--- a/specification-repository-boot4-starter/src/test/java/com/borjaglez/specrepository/boot4/SpecificationRepositoryAutoConfigurationTest.java
+++ b/specification-repository-boot4-starter/src/test/java/com/borjaglez/specrepository/boot4/SpecificationRepositoryAutoConfigurationTest.java
@@ -1,16 +1,25 @@
 package com.borjaglez.specrepository.boot4;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.context.annotation.Import;
+import org.springframework.context.support.GenericApplicationContext;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.data.jpa.repository.config.JpaRepositoryConfigExtension;
 import org.springframework.data.repository.config.BootstrapMode;
 import org.springframework.mock.env.MockEnvironment;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import com.borjaglez.specrepository.core.Operators;
+import com.borjaglez.specrepository.jpa.SpecificationRepositoryFactoryBean;
 import com.borjaglez.specrepository.jpa.SpecificationRepositoryImpl;
+import com.borjaglez.specrepository.jpa.spi.OperatorHandler;
+import com.borjaglez.specrepository.jpa.spi.SpecificationRepositoryCustomizer;
+import com.borjaglez.specrepository.jpa.spi.ValueConverter;
+import com.borjaglez.specrepository.jpa.support.PathResolver;
+import com.borjaglez.specrepository.jpa.support.SpecificationRepositoryConfiguration;
 
 class SpecificationRepositoryAutoConfigurationTest {
 
@@ -40,6 +49,46 @@ class SpecificationRepositoryAutoConfigurationTest {
 
     assertThat(annotation).isNotNull();
     assertThat(annotation.repositoryBaseClass()).isEqualTo(SpecificationRepositoryImpl.class);
+    assertThat(annotation.repositoryFactoryBeanClass())
+        .isEqualTo(SpecificationRepositoryFactoryBean.class);
+  }
+
+  @Test
+  void shouldExposeExtensionPointsThroughConfigurationBean() {
+    GenericApplicationContext context = new GenericApplicationContext();
+    context.registerBean(
+        "customOperatorHandler", OperatorHandler.class, this::customOperatorHandler);
+    context.registerBean("customValueConverter", ValueConverter.class, this::customValueConverter);
+    context.registerBean("customPathResolver", PathResolver.class, PathResolver::new);
+    context.registerBean(
+        "specificationRepositoryCustomizer",
+        SpecificationRepositoryCustomizer.class,
+        () ->
+            builder ->
+                builder
+                    .pathResolver(context.getBean("customPathResolver", PathResolver.class))
+                    .clearValueConverters()
+                    .addValueConverter(
+                        context.getBean("customValueConverter", ValueConverter.class)));
+    context.refresh();
+
+    SpecificationRepositoryConfiguration configuration =
+        new SpecificationRepositoryAutoConfiguration()
+            .specificationRepositoryConfiguration(
+                context.getBeanProvider(OperatorHandler.class),
+                context.getBeanProvider(ValueConverter.class),
+                context.getBeanProvider(SpecificationRepositoryCustomizer.class),
+                context.getBeanProvider(org.springframework.core.convert.ConversionService.class),
+                context.getBeanProvider(PathResolver.class),
+                context.getBeanProvider(
+                    com.borjaglez.specrepository.jpa.support.QueryPlanSpecificationFactory.class));
+
+    assertThat(configuration.pathResolver())
+        .isSameAs(context.getBean("customPathResolver", PathResolver.class));
+    assertThat(configuration.valueConverters())
+        .containsExactly(context.getBean("customValueConverter", ValueConverter.class));
+    assertThat(configuration.operatorHandlers())
+        .anyMatch(handler -> handler.operator().equals(Operators.custom("jsonb_eq")));
   }
 
   @Test
@@ -79,5 +128,29 @@ class SpecificationRepositoryAutoConfigurationTest {
   private static <T> T invoke(
       SpecificationJpaRepositoriesRegistrar registrar, String methodName, Class<T> resultType) {
     return resultType.cast(ReflectionTestUtils.invokeMethod(registrar, methodName));
+  }
+
+  private OperatorHandler customOperatorHandler() {
+    OperatorHandler operatorHandler = org.mockito.Mockito.mock(OperatorHandler.class);
+    when(operatorHandler.operator()).thenReturn(Operators.custom("jsonb_eq"));
+    return operatorHandler;
+  }
+
+  private ValueConverter customValueConverter() {
+    return new ValueConverter() {
+      @Override
+      public boolean supports(
+          Class<?> targetType, com.borjaglez.specrepository.core.FilterOperator operator) {
+        return true;
+      }
+
+      @Override
+      public Object convert(
+          Object value,
+          Class<?> targetType,
+          com.borjaglez.specrepository.core.FilterOperator operator) {
+        return value;
+      }
+    };
   }
 }

--- a/specification-repository-jpa/src/main/java/com/borjaglez/specrepository/jpa/EnableSpecificationRepositories.java
+++ b/specification-repository-jpa/src/main/java/com/borjaglez/specrepository/jpa/EnableSpecificationRepositories.java
@@ -9,7 +9,9 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
-@EnableJpaRepositories(repositoryBaseClass = SpecificationRepositoryImpl.class)
+@EnableJpaRepositories(
+    repositoryBaseClass = SpecificationRepositoryImpl.class,
+    repositoryFactoryBeanClass = SpecificationRepositoryFactoryBean.class)
 public @interface EnableSpecificationRepositories {
   String[] basePackages() default {};
 }

--- a/specification-repository-jpa/src/main/java/com/borjaglez/specrepository/jpa/SpecificationRepositoryFactoryBean.java
+++ b/specification-repository-jpa/src/main/java/com/borjaglez/specrepository/jpa/SpecificationRepositoryFactoryBean.java
@@ -1,0 +1,90 @@
+package com.borjaglez.specrepository.jpa;
+
+import java.io.Serializable;
+import java.util.Map;
+
+import jakarta.persistence.EntityManager;
+
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.BeanFactoryAware;
+import org.springframework.beans.factory.BeanFactoryUtils;
+import org.springframework.beans.factory.ListableBeanFactory;
+import org.springframework.data.jpa.repository.support.JpaEntityInformation;
+import org.springframework.data.jpa.repository.support.JpaRepositoryFactory;
+import org.springframework.data.jpa.repository.support.JpaRepositoryFactoryBean;
+import org.springframework.data.jpa.repository.support.JpaRepositoryImplementation;
+import org.springframework.data.repository.Repository;
+import org.springframework.data.repository.core.RepositoryInformation;
+import org.springframework.data.repository.core.RepositoryMetadata;
+import org.springframework.data.repository.core.support.RepositoryFactorySupport;
+import org.springframework.util.Assert;
+
+import com.borjaglez.specrepository.jpa.support.SpecificationRepositoryConfiguration;
+
+public class SpecificationRepositoryFactoryBean<
+        R extends Repository<T, I>, T, I extends Serializable>
+    extends JpaRepositoryFactoryBean<R, T, I> implements BeanFactoryAware {
+
+  private ListableBeanFactory beanFactory;
+
+  public SpecificationRepositoryFactoryBean(Class<? extends R> repositoryInterface) {
+    super(repositoryInterface);
+  }
+
+  @Override
+  public void setBeanFactory(BeanFactory beanFactory) {
+    Assert.isInstanceOf(ListableBeanFactory.class, beanFactory, "beanFactory must be listable");
+    super.setBeanFactory(beanFactory);
+    this.beanFactory = (ListableBeanFactory) beanFactory;
+  }
+
+  @Override
+  protected RepositoryFactorySupport createRepositoryFactory(EntityManager entityManager) {
+    return new SpecificationRepositoryFactory(entityManager, resolveConfiguration());
+  }
+
+  private SpecificationRepositoryConfiguration resolveConfiguration() {
+    if (beanFactory == null) {
+      return SpecificationRepositoryConfiguration.defaultConfiguration();
+    }
+    Map<String, SpecificationRepositoryConfiguration> configurations =
+        BeanFactoryUtils.beansOfTypeIncludingAncestors(
+            beanFactory, SpecificationRepositoryConfiguration.class, false, false);
+    if (configurations.isEmpty()) {
+      return SpecificationRepositoryConfiguration.defaultConfiguration();
+    }
+    if (configurations.size() > 1) {
+      throw new IllegalStateException(
+          "Expected a single SpecificationRepositoryConfiguration bean but found "
+              + configurations.size());
+    }
+    return configurations.values().iterator().next();
+  }
+
+  private static final class SpecificationRepositoryFactory extends JpaRepositoryFactory {
+    private final EntityManager entityManager;
+    private final SpecificationRepositoryConfiguration configuration;
+
+    private SpecificationRepositoryFactory(
+        EntityManager entityManager, SpecificationRepositoryConfiguration configuration) {
+      super(entityManager);
+      this.entityManager = entityManager;
+      this.configuration = configuration;
+    }
+
+    @Override
+    protected Class<?> getRepositoryBaseClass(RepositoryMetadata metadata) {
+      return SpecificationRepositoryImpl.class;
+    }
+
+    @Override
+    protected JpaRepositoryImplementation<?, ?> getTargetRepository(
+        RepositoryInformation information, EntityManager entityManager) {
+      JpaEntityInformation<?, Serializable> entityInformation =
+          getEntityInformation(information.getDomainType());
+      return (JpaRepositoryImplementation<?, ?>)
+          getTargetRepositoryViaReflection(
+              information, entityInformation, this.entityManager, configuration);
+    }
+  }
+}

--- a/specification-repository-jpa/src/main/java/com/borjaglez/specrepository/jpa/SpecificationRepositoryFactoryBean.java
+++ b/specification-repository-jpa/src/main/java/com/borjaglez/specrepository/jpa/SpecificationRepositoryFactoryBean.java
@@ -49,7 +49,7 @@ public class SpecificationRepositoryFactoryBean<
     }
     Map<String, SpecificationRepositoryConfiguration> configurations =
         BeanFactoryUtils.beansOfTypeIncludingAncestors(
-            beanFactory, SpecificationRepositoryConfiguration.class, false, false);
+            beanFactory, SpecificationRepositoryConfiguration.class, false, true);
     if (configurations.isEmpty()) {
       return SpecificationRepositoryConfiguration.defaultConfiguration();
     }

--- a/specification-repository-jpa/src/main/java/com/borjaglez/specrepository/jpa/SpecificationRepositoryImpl.java
+++ b/specification-repository-jpa/src/main/java/com/borjaglez/specrepository/jpa/SpecificationRepositoryImpl.java
@@ -3,6 +3,7 @@ package com.borjaglez.specrepository.jpa;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 import jakarta.persistence.EntityManager;
@@ -20,19 +21,15 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.query.QueryUtils;
 import org.springframework.data.jpa.repository.support.JpaEntityInformation;
 import org.springframework.data.jpa.repository.support.SimpleJpaRepository;
-import org.springframework.format.support.DefaultFormattingConversionService;
 
 import com.borjaglez.specrepository.core.AggregateSelection;
 import com.borjaglez.specrepository.core.FieldSelection;
 import com.borjaglez.specrepository.core.JoinMode;
 import com.borjaglez.specrepository.core.QueryPlan;
 import com.borjaglez.specrepository.jpa.support.AssociationRegistry;
-import com.borjaglez.specrepository.jpa.support.DefaultOperatorHandlers;
-import com.borjaglez.specrepository.jpa.support.DefaultValueConverters;
-import com.borjaglez.specrepository.jpa.support.OperatorRegistry;
 import com.borjaglez.specrepository.jpa.support.PathResolver;
 import com.borjaglez.specrepository.jpa.support.QueryPlanSpecificationFactory;
-import com.borjaglez.specrepository.jpa.support.ValueConversionService;
+import com.borjaglez.specrepository.jpa.support.SpecificationRepositoryConfiguration;
 
 public class SpecificationRepositoryImpl<T, ID extends Serializable>
     extends SimpleJpaRepository<T, ID> implements SpecificationRepository<T, ID> {
@@ -43,19 +40,22 @@ public class SpecificationRepositoryImpl<T, ID extends Serializable>
 
   public SpecificationRepositoryImpl(
       JpaEntityInformation<T, ?> entityInformation, EntityManager entityManager) {
+    this(
+        entityInformation,
+        entityManager,
+        SpecificationRepositoryConfiguration.defaultConfiguration());
+  }
+
+  public SpecificationRepositoryImpl(
+      JpaEntityInformation<T, ?> entityInformation,
+      EntityManager entityManager,
+      SpecificationRepositoryConfiguration configuration) {
     super(entityInformation, entityManager);
     this.entityManager = entityManager;
-    this.pathResolver = new PathResolver();
-    this.specificationFactory =
-        new QueryPlanSpecificationFactory(
-            new OperatorRegistry(DefaultOperatorHandlers.defaults()),
-            new ValueConversionService(
-                new DefaultFormattingConversionService(),
-                List.of(
-                    DefaultValueConverters.localDateConverter(),
-                    DefaultValueConverters.localDateTimeConverter(),
-                    DefaultValueConverters.datePassthroughConverter())),
-            pathResolver);
+    SpecificationRepositoryConfiguration repositoryConfiguration =
+        Objects.requireNonNull(configuration, "configuration must not be null");
+    this.pathResolver = repositoryConfiguration.pathResolver();
+    this.specificationFactory = repositoryConfiguration.specificationFactory();
   }
 
   @Override

--- a/specification-repository-jpa/src/main/java/com/borjaglez/specrepository/jpa/spi/SpecificationRepositoryCustomizer.java
+++ b/specification-repository-jpa/src/main/java/com/borjaglez/specrepository/jpa/spi/SpecificationRepositoryCustomizer.java
@@ -1,0 +1,8 @@
+package com.borjaglez.specrepository.jpa.spi;
+
+import com.borjaglez.specrepository.jpa.support.SpecificationRepositoryConfiguration;
+
+@FunctionalInterface
+public interface SpecificationRepositoryCustomizer {
+  void customize(SpecificationRepositoryConfiguration.Builder builder);
+}

--- a/specification-repository-jpa/src/main/java/com/borjaglez/specrepository/jpa/support/DefaultValueConverters.java
+++ b/specification-repository-jpa/src/main/java/com/borjaglez/specrepository/jpa/support/DefaultValueConverters.java
@@ -2,7 +2,9 @@ package com.borjaglez.specrepository.jpa.support;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.Collection;
 import java.util.Date;
+import java.util.List;
 import java.util.function.Function;
 
 import com.borjaglez.specrepository.core.FilterOperator;
@@ -10,6 +12,10 @@ import com.borjaglez.specrepository.jpa.spi.ValueConverter;
 
 public final class DefaultValueConverters {
   private DefaultValueConverters() {}
+
+  public static Collection<ValueConverter> defaults() {
+    return List.of(localDateConverter(), localDateTimeConverter(), datePassthroughConverter());
+  }
 
   public static ValueConverter localDateConverter() {
     return new SimpleValueConverter(

--- a/specification-repository-jpa/src/main/java/com/borjaglez/specrepository/jpa/support/QueryPlanSpecificationFactory.java
+++ b/specification-repository-jpa/src/main/java/com/borjaglez/specrepository/jpa/support/QueryPlanSpecificationFactory.java
@@ -36,6 +36,18 @@ public class QueryPlanSpecificationFactory {
     this.pathResolver = pathResolver;
   }
 
+  public OperatorRegistry operatorRegistry() {
+    return operatorRegistry;
+  }
+
+  public ValueConversionService valueConversionService() {
+    return valueConversionService;
+  }
+
+  public PathResolver pathResolver() {
+    return pathResolver;
+  }
+
   public <T> Specification<T> create(QueryPlan<T> plan) {
     return (root, query, criteriaBuilder) -> {
       AssociationRegistry registry = new AssociationRegistry();

--- a/specification-repository-jpa/src/main/java/com/borjaglez/specrepository/jpa/support/SpecificationRepositoryConfiguration.java
+++ b/specification-repository-jpa/src/main/java/com/borjaglez/specrepository/jpa/support/SpecificationRepositoryConfiguration.java
@@ -57,6 +57,7 @@ public final class SpecificationRepositoryConfiguration {
     private final List<ValueConverter> valueConverters = new ArrayList<>();
     private ConversionService conversionService = new DefaultFormattingConversionService();
     private PathResolver pathResolver = new PathResolver();
+    private boolean pathResolverConfigured;
     private QueryPlanSpecificationFactory specificationFactory;
 
     public Builder addDefaultOperatorHandlers() {
@@ -111,6 +112,7 @@ public final class SpecificationRepositoryConfiguration {
 
     public Builder pathResolver(PathResolver pathResolver) {
       this.pathResolver = Objects.requireNonNull(pathResolver, "pathResolver must not be null");
+      this.pathResolverConfigured = true;
       return this;
     }
 
@@ -130,6 +132,11 @@ public final class SpecificationRepositoryConfiguration {
                 new ValueConversionService(conversionService, valueConverters),
                 configuredPathResolver);
       } else {
+        if (pathResolverConfigured
+            && configuredPathResolver != configuredSpecificationFactory.pathResolver()) {
+          throw new IllegalArgumentException(
+              "pathResolver must match specificationFactory.pathResolver");
+        }
         configuredPathResolver = configuredSpecificationFactory.pathResolver();
       }
       return new SpecificationRepositoryConfiguration(

--- a/specification-repository-jpa/src/main/java/com/borjaglez/specrepository/jpa/support/SpecificationRepositoryConfiguration.java
+++ b/specification-repository-jpa/src/main/java/com/borjaglez/specrepository/jpa/support/SpecificationRepositoryConfiguration.java
@@ -1,0 +1,142 @@
+package com.borjaglez.specrepository.jpa.support;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+
+import org.springframework.core.convert.ConversionService;
+import org.springframework.format.support.DefaultFormattingConversionService;
+
+import com.borjaglez.specrepository.jpa.spi.OperatorHandler;
+import com.borjaglez.specrepository.jpa.spi.ValueConverter;
+
+public final class SpecificationRepositoryConfiguration {
+  private final List<OperatorHandler> operatorHandlers;
+  private final List<ValueConverter> valueConverters;
+  private final PathResolver pathResolver;
+  private final QueryPlanSpecificationFactory specificationFactory;
+
+  private SpecificationRepositoryConfiguration(
+      List<OperatorHandler> operatorHandlers,
+      List<ValueConverter> valueConverters,
+      PathResolver pathResolver,
+      QueryPlanSpecificationFactory specificationFactory) {
+    this.operatorHandlers = List.copyOf(operatorHandlers);
+    this.valueConverters = List.copyOf(valueConverters);
+    this.pathResolver = pathResolver;
+    this.specificationFactory = specificationFactory;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static SpecificationRepositoryConfiguration defaultConfiguration() {
+    return builder().addDefaultValueConverters().addDefaultOperatorHandlers().build();
+  }
+
+  public List<OperatorHandler> operatorHandlers() {
+    return operatorHandlers;
+  }
+
+  public List<ValueConverter> valueConverters() {
+    return valueConverters;
+  }
+
+  public PathResolver pathResolver() {
+    return pathResolver;
+  }
+
+  public QueryPlanSpecificationFactory specificationFactory() {
+    return specificationFactory;
+  }
+
+  public static final class Builder {
+    private final List<OperatorHandler> operatorHandlers = new ArrayList<>();
+    private final List<ValueConverter> valueConverters = new ArrayList<>();
+    private ConversionService conversionService = new DefaultFormattingConversionService();
+    private PathResolver pathResolver = new PathResolver();
+    private QueryPlanSpecificationFactory specificationFactory;
+
+    public Builder addDefaultOperatorHandlers() {
+      operatorHandlers.addAll(DefaultOperatorHandlers.defaults());
+      return this;
+    }
+
+    public Builder addOperatorHandler(OperatorHandler operatorHandler) {
+      operatorHandlers.add(
+          Objects.requireNonNull(operatorHandler, "operatorHandler must not be null"));
+      return this;
+    }
+
+    public Builder operatorHandlers(Collection<OperatorHandler> operatorHandlers) {
+      clearOperatorHandlers();
+      operatorHandlers.forEach(this::addOperatorHandler);
+      return this;
+    }
+
+    public Builder clearOperatorHandlers() {
+      operatorHandlers.clear();
+      return this;
+    }
+
+    public Builder addDefaultValueConverters() {
+      valueConverters.addAll(DefaultValueConverters.defaults());
+      return this;
+    }
+
+    public Builder addValueConverter(ValueConverter valueConverter) {
+      valueConverters.add(
+          Objects.requireNonNull(valueConverter, "valueConverter must not be null"));
+      return this;
+    }
+
+    public Builder valueConverters(Collection<ValueConverter> valueConverters) {
+      clearValueConverters();
+      valueConverters.forEach(this::addValueConverter);
+      return this;
+    }
+
+    public Builder clearValueConverters() {
+      valueConverters.clear();
+      return this;
+    }
+
+    public Builder conversionService(ConversionService conversionService) {
+      this.conversionService =
+          Objects.requireNonNull(conversionService, "conversionService must not be null");
+      return this;
+    }
+
+    public Builder pathResolver(PathResolver pathResolver) {
+      this.pathResolver = Objects.requireNonNull(pathResolver, "pathResolver must not be null");
+      return this;
+    }
+
+    public Builder specificationFactory(QueryPlanSpecificationFactory specificationFactory) {
+      this.specificationFactory =
+          Objects.requireNonNull(specificationFactory, "specificationFactory must not be null");
+      return this;
+    }
+
+    public SpecificationRepositoryConfiguration build() {
+      PathResolver configuredPathResolver = pathResolver;
+      QueryPlanSpecificationFactory configuredSpecificationFactory = specificationFactory;
+      if (configuredSpecificationFactory == null) {
+        configuredSpecificationFactory =
+            new QueryPlanSpecificationFactory(
+                new OperatorRegistry(operatorHandlers),
+                new ValueConversionService(conversionService, valueConverters),
+                configuredPathResolver);
+      } else {
+        configuredPathResolver = configuredSpecificationFactory.pathResolver();
+      }
+      return new SpecificationRepositoryConfiguration(
+          operatorHandlers,
+          valueConverters,
+          configuredPathResolver,
+          configuredSpecificationFactory);
+    }
+  }
+}

--- a/specification-repository-jpa/src/test/java/com/borjaglez/specrepository/jpa/EnableSpecificationRepositoriesTest.java
+++ b/specification-repository-jpa/src/test/java/com/borjaglez/specrepository/jpa/EnableSpecificationRepositoriesTest.java
@@ -1,0 +1,20 @@
+package com.borjaglez.specrepository.jpa;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+
+class EnableSpecificationRepositoriesTest {
+
+  @Test
+  void shouldUseSpecificationRepositoryFactoryBean() {
+    EnableJpaRepositories annotation =
+        EnableSpecificationRepositories.class.getAnnotation(EnableJpaRepositories.class);
+
+    assertThat(annotation).isNotNull();
+    assertThat(annotation.repositoryBaseClass()).isEqualTo(SpecificationRepositoryImpl.class);
+    assertThat(annotation.repositoryFactoryBeanClass())
+        .isEqualTo(SpecificationRepositoryFactoryBean.class);
+  }
+}

--- a/specification-repository-jpa/src/test/java/com/borjaglez/specrepository/jpa/SpecificationRepositoryFactoryBeanTest.java
+++ b/specification-repository-jpa/src/test/java/com/borjaglez/specrepository/jpa/SpecificationRepositoryFactoryBeanTest.java
@@ -3,14 +3,21 @@ package com.borjaglez.specrepository.jpa;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
+import static org.mockito.Answers.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
+
+import jakarta.persistence.EntityManager;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.support.StaticListableBeanFactory;
+import org.springframework.context.support.GenericApplicationContext;
 import org.springframework.data.repository.Repository;
+import org.springframework.data.repository.core.RepositoryMetadata;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import com.borjaglez.specrepository.jpa.support.DefaultOperatorHandlers;
+import com.borjaglez.specrepository.jpa.support.DefaultValueConverters;
 import com.borjaglez.specrepository.jpa.support.SpecificationRepositoryConfiguration;
 
 class SpecificationRepositoryFactoryBeanTest {
@@ -35,8 +42,21 @@ class SpecificationRepositoryFactoryBeanTest {
         (SpecificationRepositoryConfiguration)
             ReflectionTestUtils.invokeMethod(factoryBean, "resolveConfiguration");
 
-    assertThat(configuration.operatorHandlers()).hasSize(17);
-    assertThat(configuration.valueConverters()).hasSize(3);
+    assertThat(configuration.operatorHandlers()).hasSize(DefaultOperatorHandlers.defaults().size());
+    assertThat(configuration.valueConverters()).hasSize(DefaultValueConverters.defaults().size());
+  }
+
+  @Test
+  void shouldUseDefaultConfigurationWhenBeanFactoryWasNotSet() {
+    SpecificationRepositoryFactoryBean<TestRepository, Object, Long> factoryBean =
+        new SpecificationRepositoryFactoryBean<>(TestRepository.class);
+
+    SpecificationRepositoryConfiguration configuration =
+        (SpecificationRepositoryConfiguration)
+            ReflectionTestUtils.invokeMethod(factoryBean, "resolveConfiguration");
+
+    assertThat(configuration.operatorHandlers()).hasSize(DefaultOperatorHandlers.defaults().size());
+    assertThat(configuration.valueConverters()).hasSize(DefaultValueConverters.defaults().size());
   }
 
   @Test
@@ -53,9 +73,31 @@ class SpecificationRepositoryFactoryBeanTest {
         new SpecificationRepositoryFactoryBean<>(TestRepository.class);
     factoryBean.setBeanFactory(beanFactory);
 
-    Object resolvedConfiguration = ReflectionTestUtils.invokeMethod(factoryBean, "resolveConfiguration");
+    Object resolvedConfiguration =
+        ReflectionTestUtils.invokeMethod(factoryBean, "resolveConfiguration");
 
     assertThat(resolvedConfiguration).isSameAs(configuration);
+  }
+
+  @Test
+  void shouldResolveLazyConfigurationBean() {
+    GenericApplicationContext context = new GenericApplicationContext();
+    context.registerBean(
+        "specificationRepositoryConfiguration",
+        SpecificationRepositoryConfiguration.class,
+        SpecificationRepositoryConfiguration::defaultConfiguration,
+        definition -> definition.setLazyInit(true));
+    context.refresh();
+
+    SpecificationRepositoryFactoryBean<TestRepository, Object, Long> factoryBean =
+        new SpecificationRepositoryFactoryBean<>(TestRepository.class);
+    factoryBean.setBeanFactory(context);
+
+    Object resolvedConfiguration =
+        ReflectionTestUtils.invokeMethod(factoryBean, "resolveConfiguration");
+
+    assertThat(resolvedConfiguration)
+        .isSameAs(context.getBean("specificationRepositoryConfiguration"));
   }
 
   @Test
@@ -81,6 +123,22 @@ class SpecificationRepositoryFactoryBeanTest {
     assertThatIllegalStateException()
         .isThrownBy(() -> ReflectionTestUtils.invokeMethod(factoryBean, "resolveConfiguration"))
         .withMessageContaining("Expected a single SpecificationRepositoryConfiguration bean");
+  }
+
+  @Test
+  void shouldUseSpecificationRepositoryImplAsRepositoryBaseClass() {
+    SpecificationRepositoryFactoryBean<TestRepository, Object, Long> factoryBean =
+        new SpecificationRepositoryFactoryBean<>(TestRepository.class);
+
+    Object repositoryFactory =
+        ReflectionTestUtils.invokeMethod(
+            factoryBean, "createRepositoryFactory", mock(EntityManager.class, RETURNS_DEEP_STUBS));
+
+    Object repositoryBaseClass =
+        ReflectionTestUtils.invokeMethod(
+            repositoryFactory, "getRepositoryBaseClass", mock(RepositoryMetadata.class));
+
+    assertThat(repositoryBaseClass).isEqualTo(SpecificationRepositoryImpl.class);
   }
 
   interface TestRepository extends Repository<Object, Long> {}

--- a/specification-repository-jpa/src/test/java/com/borjaglez/specrepository/jpa/SpecificationRepositoryFactoryBeanTest.java
+++ b/specification-repository-jpa/src/test/java/com/borjaglez/specrepository/jpa/SpecificationRepositoryFactoryBeanTest.java
@@ -1,0 +1,87 @@
+package com.borjaglez.specrepository.jpa;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
+import static org.mockito.Mockito.mock;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.support.StaticListableBeanFactory;
+import org.springframework.data.repository.Repository;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.borjaglez.specrepository.jpa.support.SpecificationRepositoryConfiguration;
+
+class SpecificationRepositoryFactoryBeanTest {
+
+  @Test
+  void shouldRequireListableBeanFactory() {
+    SpecificationRepositoryFactoryBean<TestRepository, Object, Long> factoryBean =
+        new SpecificationRepositoryFactoryBean<>(TestRepository.class);
+
+    assertThatIllegalArgumentException()
+        .isThrownBy(() -> factoryBean.setBeanFactory(mock(BeanFactory.class)))
+        .withMessageContaining("beanFactory must be listable");
+  }
+
+  @Test
+  void shouldUseDefaultConfigurationWhenNoConfigurationBeanExists() {
+    SpecificationRepositoryFactoryBean<TestRepository, Object, Long> factoryBean =
+        new SpecificationRepositoryFactoryBean<>(TestRepository.class);
+    factoryBean.setBeanFactory(new StaticListableBeanFactory());
+
+    SpecificationRepositoryConfiguration configuration =
+        (SpecificationRepositoryConfiguration)
+            ReflectionTestUtils.invokeMethod(factoryBean, "resolveConfiguration");
+
+    assertThat(configuration.operatorHandlers()).hasSize(17);
+    assertThat(configuration.valueConverters()).hasSize(3);
+  }
+
+  @Test
+  void shouldUseSingleConfigurationBeanWhenPresent() {
+    SpecificationRepositoryConfiguration configuration =
+        SpecificationRepositoryConfiguration.builder()
+            .addDefaultOperatorHandlers()
+            .addDefaultValueConverters()
+            .build();
+    StaticListableBeanFactory beanFactory = new StaticListableBeanFactory();
+    beanFactory.addBean("specificationRepositoryConfiguration", configuration);
+
+    SpecificationRepositoryFactoryBean<TestRepository, Object, Long> factoryBean =
+        new SpecificationRepositoryFactoryBean<>(TestRepository.class);
+    factoryBean.setBeanFactory(beanFactory);
+
+    Object resolvedConfiguration = ReflectionTestUtils.invokeMethod(factoryBean, "resolveConfiguration");
+
+    assertThat(resolvedConfiguration).isSameAs(configuration);
+  }
+
+  @Test
+  void shouldRejectMultipleConfigurationBeans() {
+    StaticListableBeanFactory beanFactory = new StaticListableBeanFactory();
+    beanFactory.addBean(
+        "first",
+        SpecificationRepositoryConfiguration.builder()
+            .addDefaultOperatorHandlers()
+            .addDefaultValueConverters()
+            .build());
+    beanFactory.addBean(
+        "second",
+        SpecificationRepositoryConfiguration.builder()
+            .addDefaultOperatorHandlers()
+            .addDefaultValueConverters()
+            .build());
+
+    SpecificationRepositoryFactoryBean<TestRepository, Object, Long> factoryBean =
+        new SpecificationRepositoryFactoryBean<>(TestRepository.class);
+    factoryBean.setBeanFactory(beanFactory);
+
+    assertThatIllegalStateException()
+        .isThrownBy(() -> ReflectionTestUtils.invokeMethod(factoryBean, "resolveConfiguration"))
+        .withMessageContaining("Expected a single SpecificationRepositoryConfiguration bean");
+  }
+
+  interface TestRepository extends Repository<Object, Long> {}
+}

--- a/specification-repository-jpa/src/test/java/com/borjaglez/specrepository/jpa/SpecificationRepositoryImplTest.java
+++ b/specification-repository-jpa/src/test/java/com/borjaglez/specrepository/jpa/SpecificationRepositoryImplTest.java
@@ -1,19 +1,25 @@
 package com.borjaglez.specrepository.jpa;
 
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Answers.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 
 import java.util.List;
 
+import jakarta.persistence.EntityManager;
+
 import org.junit.jupiter.api.Test;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.repository.support.JpaEntityInformation;
 
 import com.borjaglez.specrepository.core.GroupCondition;
 import com.borjaglez.specrepository.core.LogicalOperator;
 import com.borjaglez.specrepository.core.QueryPlan;
+import com.borjaglez.specrepository.jpa.support.SpecificationRepositoryConfiguration;
 
 class SpecificationRepositoryImplTest {
 
@@ -60,6 +66,33 @@ class SpecificationRepositoryImplTest {
     assertThatThrownBy(() -> repository.findOneProjected(projectedPlan()))
         .isInstanceOf(UnsupportedOperationException.class)
         .hasMessage("Projected queries are not supported by this repository");
+  }
+
+  @Test
+  void shouldRejectNullConfigurationInRepositoryConstructor() {
+    JpaEntityInformation<Object, ?> entityInformation = mock(JpaEntityInformation.class);
+    EntityManager entityManager = mock(EntityManager.class, RETURNS_DEEP_STUBS);
+
+    assertThatThrownBy(
+            () ->
+                new SpecificationRepositoryImpl<>(
+                    entityInformation, entityManager, (SpecificationRepositoryConfiguration) null))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("configuration must not be null");
+  }
+
+  @Test
+  void shouldAllowCustomConfigurationInRepositoryConstructor() {
+    JpaEntityInformation<Object, ?> entityInformation = mock(JpaEntityInformation.class);
+    EntityManager entityManager = mock(EntityManager.class, RETURNS_DEEP_STUBS);
+
+    assertThatNoException()
+        .isThrownBy(
+            () ->
+                new SpecificationRepositoryImpl<>(
+                    entityInformation,
+                    entityManager,
+                    SpecificationRepositoryConfiguration.defaultConfiguration()));
   }
 
   private QueryPlan<Object> projectedPlan() {

--- a/specification-repository-jpa/src/test/java/com/borjaglez/specrepository/jpa/it/SpecificationRepositoryConfigurationIntegrationTest.java
+++ b/specification-repository-jpa/src/test/java/com/borjaglez/specrepository/jpa/it/SpecificationRepositoryConfigurationIntegrationTest.java
@@ -83,7 +83,9 @@ class SpecificationRepositoryConfigurationIntegrationTest {
     @Bean
     SpecificationRepositoryCustomizer specificationRepositoryCustomizer() {
       return builder ->
-          builder.addOperatorHandler(customEqualsOperatorHandler()).addValueConverter(ageValueConverter());
+          builder
+              .addOperatorHandler(customEqualsOperatorHandler())
+              .addValueConverter(ageValueConverter());
     }
 
     private static OperatorHandler customEqualsOperatorHandler() {

--- a/specification-repository-jpa/src/test/java/com/borjaglez/specrepository/jpa/it/SpecificationRepositoryConfigurationIntegrationTest.java
+++ b/specification-repository-jpa/src/test/java/com/borjaglez/specrepository/jpa/it/SpecificationRepositoryConfigurationIntegrationTest.java
@@ -1,0 +1,120 @@
+package com.borjaglez.specrepository.jpa.it;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import jakarta.persistence.criteria.Predicate;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.ContextConfiguration;
+
+import com.borjaglez.specrepository.core.FilterOperator;
+import com.borjaglez.specrepository.core.Operators;
+import com.borjaglez.specrepository.jpa.EnableSpecificationRepositories;
+import com.borjaglez.specrepository.jpa.spi.OperatorContext;
+import com.borjaglez.specrepository.jpa.spi.OperatorHandler;
+import com.borjaglez.specrepository.jpa.spi.SpecificationRepositoryCustomizer;
+import com.borjaglez.specrepository.jpa.spi.ValueConverter;
+import com.borjaglez.specrepository.jpa.support.SpecificationRepositoryConfiguration;
+
+@DataJpaTest
+@ContextConfiguration(
+    classes = SpecificationRepositoryConfigurationIntegrationTest.TestConfiguration.class)
+class SpecificationRepositoryConfigurationIntegrationTest {
+  private static final FilterOperator CUSTOM_EQUALS = Operators.custom("custom_equals");
+
+  @Autowired private TestCustomerRepository repository;
+
+  @BeforeEach
+  void setUp() {
+    repository.deleteAll();
+    repository.save(
+        new TestCustomer(
+            "Borja", "ACTIVE", 25, java.time.LocalDate.of(2024, 1, 10), new TestProfile("Madrid")));
+    repository.save(
+        new TestCustomer(
+            "Lucia",
+            "ACTIVE",
+            32,
+            java.time.LocalDate.of(2024, 2, 15),
+            new TestProfile("Barcelona")));
+  }
+
+  @Test
+  void shouldApplyCustomOperatorHandlerFromConfigurationBean() {
+    List<TestCustomer> results =
+        repository.query().where("status", CUSTOM_EQUALS, "ACTIVE").findAll();
+
+    assertThat(results)
+        .extracting(TestCustomer::getName)
+        .containsExactlyInAnyOrder("Borja", "Lucia");
+  }
+
+  @Test
+  void shouldApplyCustomValueConverterFromConfigurationBean() {
+    List<TestCustomer> results =
+        repository.query().where("age", Operators.EQUALS, "age:25").findAll();
+
+    assertThat(results).extracting(TestCustomer::getName).containsExactly("Borja");
+  }
+
+  @Configuration(proxyBeanMethods = false)
+  @EntityScan(basePackageClasses = TestCustomer.class)
+  @EnableSpecificationRepositories(basePackages = "com.borjaglez.specrepository.jpa.it")
+  static class TestConfiguration {
+    @Bean
+    SpecificationRepositoryConfiguration specificationRepositoryConfiguration(
+        SpecificationRepositoryCustomizer customizer) {
+      SpecificationRepositoryConfiguration.Builder builder =
+          SpecificationRepositoryConfiguration.builder()
+              .addDefaultOperatorHandlers()
+              .addDefaultValueConverters();
+      customizer.customize(builder);
+      return builder.build();
+    }
+
+    @Bean
+    SpecificationRepositoryCustomizer specificationRepositoryCustomizer() {
+      return builder ->
+          builder.addOperatorHandler(customEqualsOperatorHandler()).addValueConverter(ageValueConverter());
+    }
+
+    private static OperatorHandler customEqualsOperatorHandler() {
+      return new OperatorHandler() {
+        @Override
+        public FilterOperator operator() {
+          return CUSTOM_EQUALS;
+        }
+
+        @Override
+        public Predicate create(OperatorContext context) {
+          return context.criteriaBuilder().equal(context.path(), context.value());
+        }
+      };
+    }
+
+    private static ValueConverter ageValueConverter() {
+      return new ValueConverter() {
+        @Override
+        public boolean supports(Class<?> targetType, FilterOperator operator) {
+          return Integer.class.isAssignableFrom(targetType);
+        }
+
+        @Override
+        public Object convert(Object value, Class<?> targetType, FilterOperator operator) {
+          if (value instanceof String stringValue && stringValue.startsWith("age:")) {
+            return Integer.valueOf(stringValue.substring(4));
+          }
+          return value;
+        }
+      };
+    }
+  }
+}

--- a/specification-repository-jpa/src/test/java/com/borjaglez/specrepository/jpa/support/SpecificationRepositoryConfigurationTest.java
+++ b/specification-repository-jpa/src/test/java/com/borjaglez/specrepository/jpa/support/SpecificationRepositoryConfigurationTest.java
@@ -1,0 +1,56 @@
+package com.borjaglez.specrepository.jpa.support;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.format.support.DefaultFormattingConversionService;
+
+class SpecificationRepositoryConfigurationTest {
+
+  @Test
+  void shouldCreateDefaultConfigurationWithDefaultExtensions() {
+    SpecificationRepositoryConfiguration configuration =
+        SpecificationRepositoryConfiguration.defaultConfiguration();
+
+    assertThat(configuration.operatorHandlers()).hasSize(DefaultOperatorHandlers.defaults().size());
+    assertThat(configuration.valueConverters()).hasSize(DefaultValueConverters.defaults().size());
+    assertThat(configuration.pathResolver()).isNotNull();
+    assertThat(configuration.specificationFactory()).isNotNull();
+  }
+
+  @Test
+  void shouldReuseSpecificationFactoryPathResolverWhenFactoryIsProvided() {
+    PathResolver pathResolver = new PathResolver();
+    QueryPlanSpecificationFactory specificationFactory =
+        new QueryPlanSpecificationFactory(
+            new OperatorRegistry(DefaultOperatorHandlers.defaults()),
+            new ValueConversionService(
+                new DefaultFormattingConversionService(), DefaultValueConverters.defaults()),
+            pathResolver);
+
+    SpecificationRepositoryConfiguration configuration =
+        SpecificationRepositoryConfiguration.builder()
+            .pathResolver(new PathResolver())
+            .specificationFactory(specificationFactory)
+            .build();
+
+    assertThat(configuration.pathResolver()).isSameAs(pathResolver);
+    assertThat(configuration.specificationFactory()).isSameAs(specificationFactory);
+  }
+
+  @Test
+  void shouldExposeSpecificationFactoryCollaborators() {
+    OperatorRegistry operatorRegistry = new OperatorRegistry(DefaultOperatorHandlers.defaults());
+    ValueConversionService valueConversionService =
+        new ValueConversionService(
+            new DefaultFormattingConversionService(), DefaultValueConverters.defaults());
+    PathResolver pathResolver = new PathResolver();
+
+    QueryPlanSpecificationFactory specificationFactory =
+        new QueryPlanSpecificationFactory(operatorRegistry, valueConversionService, pathResolver);
+
+    assertThat(specificationFactory.operatorRegistry()).isSameAs(operatorRegistry);
+    assertThat(specificationFactory.valueConversionService()).isSameAs(valueConversionService);
+    assertThat(specificationFactory.pathResolver()).isSameAs(pathResolver);
+  }
+}

--- a/specification-repository-jpa/src/test/java/com/borjaglez/specrepository/jpa/support/SpecificationRepositoryConfigurationTest.java
+++ b/specification-repository-jpa/src/test/java/com/borjaglez/specrepository/jpa/support/SpecificationRepositoryConfigurationTest.java
@@ -1,9 +1,21 @@
 package com.borjaglez.specrepository.jpa.support;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+
+import java.util.List;
+
+import jakarta.persistence.criteria.Predicate;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.format.support.DefaultFormattingConversionService;
+
+import com.borjaglez.specrepository.core.FilterOperator;
+import com.borjaglez.specrepository.core.Operators;
+import com.borjaglez.specrepository.jpa.spi.OperatorContext;
+import com.borjaglez.specrepository.jpa.spi.OperatorHandler;
+import com.borjaglez.specrepository.jpa.spi.ValueConverter;
 
 class SpecificationRepositoryConfigurationTest {
 
@@ -19,6 +31,74 @@ class SpecificationRepositoryConfigurationTest {
   }
 
   @Test
+  void shouldReplaceConfiguredExtensionsWithCollections() {
+    OperatorHandler operatorHandler = customOperatorHandler();
+    ValueConverter valueConverter = customValueConverter();
+
+    SpecificationRepositoryConfiguration configuration =
+        SpecificationRepositoryConfiguration.builder()
+            .addDefaultOperatorHandlers()
+            .addDefaultValueConverters()
+            .operatorHandlers(List.of(operatorHandler))
+            .valueConverters(List.of(valueConverter))
+            .build();
+
+    assertThat(configuration.operatorHandlers()).containsExactly(operatorHandler);
+    assertThat(configuration.valueConverters()).containsExactly(valueConverter);
+  }
+
+  @Test
+  void shouldApplyExplicitConversionService() {
+    SpecificationRepositoryConfiguration configuration =
+        SpecificationRepositoryConfiguration.builder()
+            .conversionService(new DefaultFormattingConversionService())
+            .addDefaultOperatorHandlers()
+            .addDefaultValueConverters()
+            .build();
+
+    assertThat(configuration.specificationFactory()).isNotNull();
+  }
+
+  @Test
+  void shouldRejectNullCollaborators() {
+    assertThatNullPointerException()
+        .isThrownBy(() -> SpecificationRepositoryConfiguration.builder().addOperatorHandler(null))
+        .withMessage("operatorHandler must not be null");
+    assertThatNullPointerException()
+        .isThrownBy(() -> SpecificationRepositoryConfiguration.builder().addValueConverter(null))
+        .withMessage("valueConverter must not be null");
+    assertThatNullPointerException()
+        .isThrownBy(() -> SpecificationRepositoryConfiguration.builder().conversionService(null))
+        .withMessage("conversionService must not be null");
+    assertThatNullPointerException()
+        .isThrownBy(() -> SpecificationRepositoryConfiguration.builder().pathResolver(null))
+        .withMessage("pathResolver must not be null");
+    assertThatNullPointerException()
+        .isThrownBy(() -> SpecificationRepositoryConfiguration.builder().specificationFactory(null))
+        .withMessage("specificationFactory must not be null");
+  }
+
+  @Test
+  void shouldAllowMatchingExplicitPathResolverWithFactory() {
+    PathResolver pathResolver = new PathResolver();
+    QueryPlanSpecificationFactory specificationFactory =
+        new QueryPlanSpecificationFactory(
+            new OperatorRegistry(DefaultOperatorHandlers.defaults()),
+            new ValueConversionService(
+                new DefaultFormattingConversionService(), DefaultValueConverters.defaults()),
+            pathResolver);
+
+    SpecificationRepositoryConfiguration configuration =
+        SpecificationRepositoryConfiguration.builder()
+            .pathResolver(pathResolver)
+            .specificationFactory(specificationFactory)
+            .build();
+
+    assertThat(configuration.pathResolver()).isSameAs(pathResolver);
+    assertThat(configuration.specificationFactory()).isSameAs(specificationFactory);
+  }
+
+  @Test
   void shouldReuseSpecificationFactoryPathResolverWhenFactoryIsProvided() {
     PathResolver pathResolver = new PathResolver();
     QueryPlanSpecificationFactory specificationFactory =
@@ -30,12 +110,30 @@ class SpecificationRepositoryConfigurationTest {
 
     SpecificationRepositoryConfiguration configuration =
         SpecificationRepositoryConfiguration.builder()
-            .pathResolver(new PathResolver())
             .specificationFactory(specificationFactory)
             .build();
 
     assertThat(configuration.pathResolver()).isSameAs(pathResolver);
     assertThat(configuration.specificationFactory()).isSameAs(specificationFactory);
+  }
+
+  @Test
+  void shouldRejectDifferentPathResolverWhenFactoryIsProvided() {
+    QueryPlanSpecificationFactory specificationFactory =
+        new QueryPlanSpecificationFactory(
+            new OperatorRegistry(DefaultOperatorHandlers.defaults()),
+            new ValueConversionService(
+                new DefaultFormattingConversionService(), DefaultValueConverters.defaults()),
+            new PathResolver());
+
+    assertThatIllegalArgumentException()
+        .isThrownBy(
+            () ->
+                SpecificationRepositoryConfiguration.builder()
+                    .pathResolver(new PathResolver())
+                    .specificationFactory(specificationFactory)
+                    .build())
+        .withMessage("pathResolver must match specificationFactory.pathResolver");
   }
 
   @Test
@@ -52,5 +150,33 @@ class SpecificationRepositoryConfigurationTest {
     assertThat(specificationFactory.operatorRegistry()).isSameAs(operatorRegistry);
     assertThat(specificationFactory.valueConversionService()).isSameAs(valueConversionService);
     assertThat(specificationFactory.pathResolver()).isSameAs(pathResolver);
+  }
+
+  private static OperatorHandler customOperatorHandler() {
+    return new OperatorHandler() {
+      @Override
+      public FilterOperator operator() {
+        return Operators.custom("custom");
+      }
+
+      @Override
+      public Predicate create(OperatorContext context) {
+        return null;
+      }
+    };
+  }
+
+  private static ValueConverter customValueConverter() {
+    return new ValueConverter() {
+      @Override
+      public boolean supports(Class<?> targetType, FilterOperator operator) {
+        return true;
+      }
+
+      @Override
+      public Object convert(Object value, Class<?> targetType, FilterOperator operator) {
+        return value;
+      }
+    };
   }
 }


### PR DESCRIPTION
Closes #20

## Summary
- expose specification repository extension points through Spring Boot beans and a configurable repository factory
- allow custom OperatorHandler, ValueConverter, and SpecificationRepositoryCustomizer registrations in Boot 3 and Boot 4 starters
- add unit and integration coverage plus documentation for the new customization flow

## Checklist
- [x] Tests added or updated
- [x] Documentation updated
- [x] Backward compatibility reviewed

## Test Plan
- [x] ./gradlew :specification-repository-jpa:test --tests \"com.borjaglez.specrepository.jpa.SpecificationRepositoryFactoryBeanTest\" --tests \"com.borjaglez.specrepository.jpa.support.SpecificationRepositoryConfigurationTest\" --tests \"com.borjaglez.specrepository.jpa.it.SpecificationRepositoryConfigurationIntegrationTest\" :specification-repository-boot3-starter:test --tests \"com.borjaglez.specrepository.boot3.SpecificationRepositoryAutoConfigurationTest\" --tests \"com.borjaglez.specrepository.boot3.SpecificationRepositoryAutoConfigurationIntegrationTest\" :specification-repository-boot4-starter:test --tests \"com.borjaglez.specrepository.boot4.SpecificationRepositoryAutoConfigurationTest\" --tests \"com.borjaglez.specrepository.boot4.SpecificationRepositoryAutoConfigurationIntegrationTest\"