### PR TITLE
feat: add field whitelist for filtering and sorting

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Extensible Spring Data JPA query library with a fluent DSL and native-friendly a
 - Aggregate projections with `sum`, `avg`, `min`, `max`, and `count(field)`
 - Pure builder model -- the builder only creates an immutable query plan
 - `SpecificationRepository` as a repository base abstraction for execution
+- Per-query field whitelisting for secure API exposure (`AllowedFieldsPolicy`)
 - Pluggable operators, predicate factories, converters, and dialect extensions
 - GraalVM-aware path resolution based on JPA metamodel metadata instead of reflection-heavy lookup
 - Spring Boot 3 and Spring Boot 4 starter modules
@@ -403,6 +404,35 @@ PostgreSQL `unaccent` extension to be enabled.
 
 Important: this is NOT a portable SQL abstraction yet. If you run the same overload on another
 dialect, you must provide a compatible database function or replace the operator handling strategy.
+
+### Field Whitelisting
+
+When the DSL is exposed through a public API, restrict which fields clients can filter and sort by:
+
+```java
+AllowedFieldsPolicy policy = AllowedFieldsPolicy.of(
+    Set.of("name", "email", "status"),   // allowed for filtering
+    Set.of("name", "createdAt"));        // allowed for sorting
+
+List<User> users = userRepository.query()
+    .allowedFields(policy)
+    .where("name", Operators.CONTAINS, searchTerm)
+    .sort(Sort.by("createdAt"))
+    .findAll();
+```
+
+Attempting to filter or sort by a non-whitelisted field throws `DisallowedFieldException`:
+
+```java
+// Throws: "Field 'passwordHash' is not allowed for filtering"
+userRepository.query()
+    .allowedFields(policy)
+    .where("passwordHash", Operators.EQUALS, value)
+    .findAll();
+```
+
+The policy is per-query, so each endpoint can define its own restrictions. Without
+`allowedFields()`, all fields are permitted (backward-compatible default).
 
 ### Pre-Built Query Plans
 

--- a/docs/extensibility.md
+++ b/docs/extensibility.md
@@ -21,3 +21,48 @@ The Boot 3 and Boot 4 starters expose extensibility through beans:
 - `ValueConverter` beans are applied before the defaults, so domain-specific converters can override standard parsing.
 - `SpecificationRepositoryCustomizer` beans can tweak the `SpecificationRepositoryConfiguration.Builder` before the final repository pipeline is created.
 - Advanced scenarios can provide `PathResolver`, `ConversionService`, `QueryPlanSpecificationFactory`, or a full `SpecificationRepositoryConfiguration` bean.
+
+## Field whitelisting
+
+When the DSL is exposed through a public HTTP API, restrict which fields clients can filter and sort by using `AllowedFieldsPolicy`. The policy is applied per-query, so each endpoint can define its own restrictions.
+
+```java
+// Define a policy — only these fields are allowed
+AllowedFieldsPolicy policy = AllowedFieldsPolicy.of(
+    Set.of("name", "email", "status"),   // allowed for filtering
+    Set.of("name", "createdAt"));        // allowed for sorting
+
+// Apply to a query — disallowed fields throw DisallowedFieldException
+List<User> users = userRepository.query()
+    .allowedFields(policy)
+    .where("name", Operators.CONTAINS, searchTerm)
+    .sort(Sort.by("createdAt"))
+    .findAll();
+```
+
+Without `allowedFields()`, all fields are permitted (backward-compatible default).
+
+### Security example: REST controller
+
+```java
+@RestController
+@RequestMapping("/api/users")
+class UserController {
+  private static final AllowedFieldsPolicy USER_POLICY = AllowedFieldsPolicy.of(
+      Set.of("name", "email", "status", "createdAt"),
+      Set.of("name", "createdAt"));
+
+  @GetMapping
+  Page<User> search(
+      @RequestParam String field,
+      @RequestParam String value,
+      Pageable pageable) {
+    return userRepository.query()
+        .allowedFields(USER_POLICY)
+        .where(field, Operators.EQUALS, value)
+        .findAll(pageable);
+  }
+}
+```
+
+Attempting to filter by `passwordHash` or sort by `internalScore` throws `DisallowedFieldException` with a clear message: `"Field 'passwordHash' is not allowed for filtering"`.

--- a/specification-repository-core/src/main/java/com/borjaglez/specrepository/core/AllowedFieldsPolicy.java
+++ b/specification-repository-core/src/main/java/com/borjaglez/specrepository/core/AllowedFieldsPolicy.java
@@ -1,0 +1,42 @@
+package com.borjaglez.specrepository.core;
+
+import java.util.Objects;
+import java.util.Set;
+
+public final class AllowedFieldsPolicy {
+  private static final AllowedFieldsPolicy ALLOW_ALL = new AllowedFieldsPolicy(null, null);
+
+  private final Set<String> filterableFields;
+  private final Set<String> sortableFields;
+
+  private AllowedFieldsPolicy(Set<String> filterableFields, Set<String> sortableFields) {
+    this.filterableFields = filterableFields;
+    this.sortableFields = sortableFields;
+  }
+
+  public static AllowedFieldsPolicy allowAll() {
+    return ALLOW_ALL;
+  }
+
+  public static AllowedFieldsPolicy of(Set<String> filterable, Set<String> sortable) {
+    Objects.requireNonNull(filterable, "filterable must not be null");
+    Objects.requireNonNull(sortable, "sortable must not be null");
+    return new AllowedFieldsPolicy(Set.copyOf(filterable), Set.copyOf(sortable));
+  }
+
+  public void validateFilter(String field) {
+    if (filterableFields != null && !filterableFields.contains(field)) {
+      throw new DisallowedFieldException(field, "filtering");
+    }
+  }
+
+  public void validateSort(String field) {
+    if (sortableFields != null && !sortableFields.contains(field)) {
+      throw new DisallowedFieldException(field, "sorting");
+    }
+  }
+
+  public boolean isAllowAll() {
+    return this == ALLOW_ALL;
+  }
+}

--- a/specification-repository-core/src/main/java/com/borjaglez/specrepository/core/DisallowedFieldException.java
+++ b/specification-repository-core/src/main/java/com/borjaglez/specrepository/core/DisallowedFieldException.java
@@ -1,0 +1,20 @@
+package com.borjaglez.specrepository.core;
+
+public class DisallowedFieldException extends IllegalArgumentException {
+  private final String field;
+  private final String usage;
+
+  public DisallowedFieldException(String field, String usage) {
+    super("Field '" + field + "' is not allowed for " + usage);
+    this.field = field;
+    this.usage = usage;
+  }
+
+  public String field() {
+    return field;
+  }
+
+  public String usage() {
+    return usage;
+  }
+}

--- a/specification-repository-core/src/main/java/com/borjaglez/specrepository/core/QueryPlan.java
+++ b/specification-repository-core/src/main/java/com/borjaglez/specrepository/core/QueryPlan.java
@@ -1,6 +1,7 @@
 package com.borjaglez.specrepository.core;
 
 import java.util.List;
+import java.util.Objects;
 
 import org.springframework.data.domain.Sort;
 
@@ -16,6 +17,35 @@ public record QueryPlan<T>(
     Sort sort,
     boolean distinct,
     AllowedFieldsPolicy allowedFieldsPolicy) {
+
+  public QueryPlan {
+    Objects.requireNonNull(allowedFieldsPolicy, "allowedFieldsPolicy must not be null");
+  }
+
+  public QueryPlan(
+      Class<T> entityType,
+      GroupCondition rootCondition,
+      List<JoinInstruction> joins,
+      List<FetchInstruction> fetches,
+      List<String> projections,
+      List<Selection> selections,
+      Class<?> projectionType,
+      List<String> groupBy,
+      Sort sort,
+      boolean distinct) {
+    this(
+        entityType,
+        rootCondition,
+        joins,
+        fetches,
+        projections,
+        selections,
+        projectionType,
+        groupBy,
+        sort,
+        distinct,
+        AllowedFieldsPolicy.allowAll());
+  }
 
   public boolean hasSelections() {
     return !selections.isEmpty();

--- a/specification-repository-core/src/main/java/com/borjaglez/specrepository/core/QueryPlan.java
+++ b/specification-repository-core/src/main/java/com/borjaglez/specrepository/core/QueryPlan.java
@@ -14,7 +14,8 @@ public record QueryPlan<T>(
     Class<?> projectionType,
     List<String> groupBy,
     Sort sort,
-    boolean distinct) {
+    boolean distinct,
+    AllowedFieldsPolicy allowedFieldsPolicy) {
 
   public boolean hasSelections() {
     return !selections.isEmpty();

--- a/specification-repository-core/src/main/java/com/borjaglez/specrepository/core/QueryPlanBuilder.java
+++ b/specification-repository-core/src/main/java/com/borjaglez/specrepository/core/QueryPlanBuilder.java
@@ -20,6 +20,7 @@ public class QueryPlanBuilder<T> {
   private Sort sort = Sort.unsorted();
   private Class<?> projectionType;
   private boolean distinct;
+  private AllowedFieldsPolicy allowedFieldsPolicy = AllowedFieldsPolicy.allowAll();
 
   public QueryPlanBuilder(Class<T> entityType) {
     this.entityType = Objects.requireNonNull(entityType, "entityType must not be null");
@@ -114,6 +115,12 @@ public class QueryPlanBuilder<T> {
     return this;
   }
 
+  public QueryPlanBuilder<T> allowedFields(AllowedFieldsPolicy allowedFieldsPolicy) {
+    this.allowedFieldsPolicy =
+        Objects.requireNonNull(allowedFieldsPolicy, "allowedFieldsPolicy must not be null");
+    return this;
+  }
+
   public QueryPlanBuilder<T> distinct() {
     this.distinct = true;
     return this;
@@ -134,7 +141,8 @@ public class QueryPlanBuilder<T> {
         projectionType,
         List.copyOf(groupBy),
         sort,
-        distinct);
+        distinct,
+        allowedFieldsPolicy);
   }
 
   protected final <P> QueryPlanBuilder<T> selectIntoInternal(Class<P> projectionType) {

--- a/specification-repository-core/src/test/java/com/borjaglez/specrepository/core/AllowedFieldsPolicyTest.java
+++ b/specification-repository-core/src/test/java/com/borjaglez/specrepository/core/AllowedFieldsPolicyTest.java
@@ -1,0 +1,104 @@
+package com.borjaglez.specrepository.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+class AllowedFieldsPolicyTest {
+
+  @Test
+  void allowAllShouldPermitAnyFieldForFiltering() {
+    AllowedFieldsPolicy policy = AllowedFieldsPolicy.allowAll();
+
+    policy.validateFilter("anyField");
+    policy.validateFilter("nested.path");
+  }
+
+  @Test
+  void allowAllShouldPermitAnyFieldForSorting() {
+    AllowedFieldsPolicy policy = AllowedFieldsPolicy.allowAll();
+
+    policy.validateSort("anyField");
+    policy.validateSort("nested.path");
+  }
+
+  @Test
+  void allowAllShouldReturnTrueForIsAllowAll() {
+    assertThat(AllowedFieldsPolicy.allowAll().isAllowAll()).isTrue();
+  }
+
+  @Test
+  void restrictedPolicyShouldReturnFalseForIsAllowAll() {
+    AllowedFieldsPolicy policy = AllowedFieldsPolicy.of(Set.of("name"), Set.of("name"));
+
+    assertThat(policy.isAllowAll()).isFalse();
+  }
+
+  @Test
+  void shouldAllowWhitelistedFilterFields() {
+    AllowedFieldsPolicy policy = AllowedFieldsPolicy.of(Set.of("name", "email"), Set.of("name"));
+
+    policy.validateFilter("name");
+    policy.validateFilter("email");
+  }
+
+  @Test
+  void shouldRejectNonWhitelistedFilterFields() {
+    AllowedFieldsPolicy policy = AllowedFieldsPolicy.of(Set.of("name"), Set.of("name"));
+
+    assertThatExceptionOfType(DisallowedFieldException.class)
+        .isThrownBy(() -> policy.validateFilter("secretKey"))
+        .withMessage("Field 'secretKey' is not allowed for filtering")
+        .satisfies(
+            ex -> {
+              assertThat(ex.field()).isEqualTo("secretKey");
+              assertThat(ex.usage()).isEqualTo("filtering");
+            });
+  }
+
+  @Test
+  void shouldAllowWhitelistedSortFields() {
+    AllowedFieldsPolicy policy =
+        AllowedFieldsPolicy.of(Set.of("name"), Set.of("name", "createdAt"));
+
+    policy.validateSort("name");
+    policy.validateSort("createdAt");
+  }
+
+  @Test
+  void shouldRejectNonWhitelistedSortFields() {
+    AllowedFieldsPolicy policy = AllowedFieldsPolicy.of(Set.of("name"), Set.of("name"));
+
+    assertThatExceptionOfType(DisallowedFieldException.class)
+        .isThrownBy(() -> policy.validateSort("internalScore"))
+        .withMessage("Field 'internalScore' is not allowed for sorting")
+        .satisfies(
+            ex -> {
+              assertThat(ex.field()).isEqualTo("internalScore");
+              assertThat(ex.usage()).isEqualTo("sorting");
+            });
+  }
+
+  @Test
+  void shouldReturnSameSingletonForAllowAll() {
+    assertThat(AllowedFieldsPolicy.allowAll()).isSameAs(AllowedFieldsPolicy.allowAll());
+  }
+
+  @Test
+  void shouldRejectNullFilterableSet() {
+    assertThatNullPointerException()
+        .isThrownBy(() -> AllowedFieldsPolicy.of(null, Set.of()))
+        .withMessage("filterable must not be null");
+  }
+
+  @Test
+  void shouldRejectNullSortableSet() {
+    assertThatNullPointerException()
+        .isThrownBy(() -> AllowedFieldsPolicy.of(Set.of(), null))
+        .withMessage("sortable must not be null");
+  }
+}

--- a/specification-repository-core/src/test/java/com/borjaglez/specrepository/core/QueryPlanBuilderTest.java
+++ b/specification-repository-core/src/test/java/com/borjaglez/specrepository/core/QueryPlanBuilderTest.java
@@ -193,6 +193,23 @@ class QueryPlanBuilderTest {
     assertThat(plan.groupBy()).isEmpty();
     assertThat(plan.hasSelections()).isFalse();
     assertThat(plan.hasAggregates()).isFalse();
+    assertThat(plan.allowedFieldsPolicy()).isSameAs(AllowedFieldsPolicy.allowAll());
+  }
+
+  @Test
+  void shouldStoreAllowedFieldsPolicy() {
+    AllowedFieldsPolicy policy =
+        AllowedFieldsPolicy.of(java.util.Set.of("name"), java.util.Set.of("name"));
+    QueryPlan<String> plan = new QueryPlanBuilder<>(String.class).allowedFields(policy).build();
+
+    assertThat(plan.allowedFieldsPolicy()).isSameAs(policy);
+  }
+
+  @Test
+  void allowedFieldsShouldRejectNull() {
+    assertThatNullPointerException()
+        .isThrownBy(() -> new QueryPlanBuilder<>(String.class).allowedFields(null))
+        .withMessage("allowedFieldsPolicy must not be null");
   }
 
   @Test

--- a/specification-repository-core/src/test/java/com/borjaglez/specrepository/core/QueryPlanBuilderTest.java
+++ b/specification-repository-core/src/test/java/com/borjaglez/specrepository/core/QueryPlanBuilderTest.java
@@ -213,6 +213,44 @@ class QueryPlanBuilderTest {
   }
 
   @Test
+  void queryPlanCompatibilityConstructorShouldDefaultToAllowAll() {
+    QueryPlan<String> plan =
+        new QueryPlan<>(
+            String.class,
+            new GroupCondition(LogicalOperator.AND, java.util.List.of()),
+            java.util.List.of(),
+            java.util.List.of(),
+            java.util.List.of(),
+            java.util.List.of(),
+            null,
+            java.util.List.of(),
+            Sort.unsorted(),
+            false);
+
+    assertThat(plan.allowedFieldsPolicy()).isSameAs(AllowedFieldsPolicy.allowAll());
+  }
+
+  @Test
+  void queryPlanShouldRejectNullAllowedFieldsPolicy() {
+    assertThatNullPointerException()
+        .isThrownBy(
+            () ->
+                new QueryPlan<>(
+                    String.class,
+                    new GroupCondition(LogicalOperator.AND, java.util.List.of()),
+                    java.util.List.of(),
+                    java.util.List.of(),
+                    java.util.List.of(),
+                    java.util.List.of(),
+                    null,
+                    java.util.List.of(),
+                    Sort.unsorted(),
+                    false,
+                    null))
+        .withMessage("allowedFieldsPolicy must not be null");
+  }
+
+  @Test
   void specificationQueryBuilderForEntityShouldReturnBuilder() {
     QueryPlanBuilder<Integer> builder = SpecificationQueryBuilder.forEntity(Integer.class);
     QueryPlan<Integer> plan = builder.build();

--- a/specification-repository-jpa/src/main/java/com/borjaglez/specrepository/jpa/SpecificationExecutableQuery.java
+++ b/specification-repository-jpa/src/main/java/com/borjaglez/specrepository/jpa/SpecificationExecutableQuery.java
@@ -8,6 +8,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 
+import com.borjaglez.specrepository.core.AllowedFieldsPolicy;
 import com.borjaglez.specrepository.core.ConditionGroupBuilder;
 import com.borjaglez.specrepository.core.FilterOperator;
 import com.borjaglez.specrepository.core.QueryPlan;
@@ -133,6 +134,12 @@ public class SpecificationExecutableQuery<T> extends QueryPlanBuilder<T> {
   @Override
   public SpecificationExecutableQuery<T> sort(Sort sort) {
     super.sort(sort);
+    return this;
+  }
+
+  @Override
+  public SpecificationExecutableQuery<T> allowedFields(AllowedFieldsPolicy allowedFieldsPolicy) {
+    super.allowedFields(allowedFieldsPolicy);
     return this;
   }
 

--- a/specification-repository-jpa/src/main/java/com/borjaglez/specrepository/jpa/support/QueryPlanSpecificationFactory.java
+++ b/specification-repository-jpa/src/main/java/com/borjaglez/specrepository/jpa/support/QueryPlanSpecificationFactory.java
@@ -12,6 +12,7 @@ import jakarta.persistence.criteria.Root;
 
 import org.springframework.data.jpa.domain.Specification;
 
+import com.borjaglez.specrepository.core.AllowedFieldsPolicy;
 import com.borjaglez.specrepository.core.FetchInstruction;
 import com.borjaglez.specrepository.core.GroupCondition;
 import com.borjaglez.specrepository.core.JoinInstruction;
@@ -49,6 +50,7 @@ public class QueryPlanSpecificationFactory {
   }
 
   public <T> Specification<T> create(QueryPlan<T> plan) {
+    validateFields(plan);
     return (root, query, criteriaBuilder) -> {
       AssociationRegistry registry = new AssociationRegistry();
       applyJoins(root, registry, plan.joins());
@@ -136,5 +138,27 @@ public class QueryPlanSpecificationFactory {
     return condition.logicalOperator() == LogicalOperator.OR
         ? criteriaBuilder.or(predicateArray)
         : criteriaBuilder.and(predicateArray);
+  }
+
+  private <T> void validateFields(QueryPlan<T> plan) {
+    AllowedFieldsPolicy policy = plan.allowedFieldsPolicy();
+    if (policy.isAllowAll()) {
+      return;
+    }
+    validateFilterFields(policy, plan.rootCondition());
+    if (plan.sort().isSorted()) {
+      plan.sort().forEach(order -> policy.validateSort(order.getProperty()));
+    }
+  }
+
+  private void validateFilterFields(AllowedFieldsPolicy policy, GroupCondition group) {
+    for (QueryCondition condition : group.conditions()) {
+      if (condition instanceof PredicateCondition predicate) {
+        policy.validateFilter(predicate.field());
+      }
+      if (condition instanceof GroupCondition nested) {
+        validateFilterFields(policy, nested);
+      }
+    }
   }
 }

--- a/specification-repository-jpa/src/test/java/com/borjaglez/specrepository/jpa/SpecificationRepositoryImplTest.java
+++ b/specification-repository-jpa/src/test/java/com/borjaglez/specrepository/jpa/SpecificationRepositoryImplTest.java
@@ -16,6 +16,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.support.JpaEntityInformation;
 
+import com.borjaglez.specrepository.core.AllowedFieldsPolicy;
 import com.borjaglez.specrepository.core.GroupCondition;
 import com.borjaglez.specrepository.core.LogicalOperator;
 import com.borjaglez.specrepository.core.QueryPlan;
@@ -40,7 +41,8 @@ class SpecificationRepositoryImplTest {
             null,
             List.of(),
             Sort.unsorted(),
-            false);
+            false,
+            AllowedFieldsPolicy.allowAll());
 
     assertThatIllegalStateException()
         .isThrownBy(() -> SpecificationRepositoryImpl.requiredProjectionType(plan))
@@ -106,7 +108,8 @@ class SpecificationRepositoryImplTest {
         Projection.class,
         List.of(),
         Sort.unsorted(),
-        false);
+        false,
+        AllowedFieldsPolicy.allowAll());
   }
 
   private record Projection(String name) {}

--- a/specification-repository-jpa/src/test/java/com/borjaglez/specrepository/jpa/it/SpecificationRepositoryIntegrationTest.java
+++ b/specification-repository-jpa/src/test/java/com/borjaglez/specrepository/jpa/it/SpecificationRepositoryIntegrationTest.java
@@ -7,6 +7,7 @@ import static org.assertj.core.api.Assertions.tuple;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -19,6 +20,8 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.test.context.ContextConfiguration;
 
+import com.borjaglez.specrepository.core.AllowedFieldsPolicy;
+import com.borjaglez.specrepository.core.DisallowedFieldException;
 import com.borjaglez.specrepository.core.Operators;
 import com.borjaglez.specrepository.core.QueryPlan;
 import com.borjaglez.specrepository.jpa.SpecificationRepositoryImpl;
@@ -748,6 +751,54 @@ class SpecificationRepositoryIntegrationTest {
     List<TestCustomer> results = repository.query().findAll();
 
     assertThat(results).hasSize(4);
+  }
+
+  // -- Allowed fields policy --
+
+  @Test
+  void shouldFilterWithAllowedFieldsPolicy() {
+    AllowedFieldsPolicy policy = AllowedFieldsPolicy.of(Set.of("name", "status"), Set.of("name"));
+
+    List<TestCustomer> results =
+        repository
+            .query()
+            .allowedFields(policy)
+            .where("status", Operators.EQUALS, "ACTIVE")
+            .sort(Sort.by("name"))
+            .findAll();
+
+    assertThat(results).hasSize(2);
+  }
+
+  @Test
+  void shouldRejectDisallowedFilterFieldWithPolicy() {
+    AllowedFieldsPolicy policy = AllowedFieldsPolicy.of(Set.of("name"), Set.of("name"));
+
+    assertThatThrownBy(
+            () ->
+                repository
+                    .query()
+                    .allowedFields(policy)
+                    .where("status", Operators.EQUALS, "ACTIVE")
+                    .findAll())
+        .isInstanceOf(DisallowedFieldException.class)
+        .hasMessage("Field 'status' is not allowed for filtering");
+  }
+
+  @Test
+  void shouldRejectDisallowedSortFieldWithPolicy() {
+    AllowedFieldsPolicy policy = AllowedFieldsPolicy.of(Set.of("name"), Set.of("name"));
+
+    assertThatThrownBy(
+            () ->
+                repository
+                    .query()
+                    .allowedFields(policy)
+                    .where("name", Operators.EQUALS, "Borja")
+                    .sort(Sort.by("status"))
+                    .findAll())
+        .isInstanceOf(DisallowedFieldException.class)
+        .hasMessage("Field 'status' is not allowed for sorting");
   }
 
   @Configuration(proxyBeanMethods = false)

--- a/specification-repository-jpa/src/test/java/com/borjaglez/specrepository/jpa/support/QueryPlanSpecificationFactoryTest.java
+++ b/specification-repository-jpa/src/test/java/com/borjaglez/specrepository/jpa/support/QueryPlanSpecificationFactoryTest.java
@@ -1,6 +1,7 @@
 package com.borjaglez.specrepository.jpa.support;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
@@ -10,6 +11,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
+import java.util.Set;
 
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.CriteriaQuery;
@@ -22,6 +24,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.domain.Specification;
 
+import com.borjaglez.specrepository.core.AllowedFieldsPolicy;
+import com.borjaglez.specrepository.core.DisallowedFieldException;
 import com.borjaglez.specrepository.core.FetchInstruction;
 import com.borjaglez.specrepository.core.GroupCondition;
 import com.borjaglez.specrepository.core.JoinInstruction;
@@ -83,7 +87,8 @@ class QueryPlanSpecificationFactoryTest {
             null,
             List.of(),
             Sort.unsorted(),
-            true);
+            true,
+            AllowedFieldsPolicy.allowAll());
 
     Specification<Object> spec = factory.create(plan);
     spec.toPredicate(root, query, cb);
@@ -116,7 +121,8 @@ class QueryPlanSpecificationFactoryTest {
             null,
             List.of(),
             Sort.unsorted(),
-            false);
+            false,
+            AllowedFieldsPolicy.allowAll());
 
     Specification<Object> spec = factory.create(plan);
     spec.toPredicate(root, query, cb);
@@ -140,7 +146,8 @@ class QueryPlanSpecificationFactoryTest {
             null,
             List.of(),
             Sort.unsorted(),
-            false);
+            false,
+            AllowedFieldsPolicy.allowAll());
 
     doReturn(Object.class).when(query).getResultType();
 
@@ -166,7 +173,8 @@ class QueryPlanSpecificationFactoryTest {
             null,
             List.of(),
             Sort.unsorted(),
-            false);
+            false,
+            AllowedFieldsPolicy.allowAll());
 
     doReturn(Long.class).when(query).getResultType();
 
@@ -191,7 +199,8 @@ class QueryPlanSpecificationFactoryTest {
             null,
             List.of(),
             Sort.unsorted(),
-            false);
+            false,
+            AllowedFieldsPolicy.allowAll());
 
     doReturn(long.class).when(query).getResultType();
 
@@ -216,7 +225,8 @@ class QueryPlanSpecificationFactoryTest {
             null,
             groupBy,
             Sort.unsorted(),
-            false);
+            false,
+            AllowedFieldsPolicy.allowAll());
 
     Path<?> statusPath = mock(Path.class);
     Path<?> namePath = mock(Path.class);
@@ -411,7 +421,121 @@ class QueryPlanSpecificationFactoryTest {
     verify(query).where(combined);
   }
 
+  @Test
+  void shouldRejectDisallowedFilterField() {
+    AllowedFieldsPolicy policy = AllowedFieldsPolicy.of(Set.of("name"), Set.of("name"));
+    PredicateCondition c1 =
+        new PredicateCondition("secretKey", Operators.EQUALS, "value", false, false);
+    GroupCondition rootCondition = new GroupCondition(LogicalOperator.AND, List.of(c1));
+    QueryPlan<Object> plan = plan(rootCondition, Sort.unsorted(), policy);
+
+    assertThatExceptionOfType(DisallowedFieldException.class)
+        .isThrownBy(() -> factory.create(plan))
+        .withMessage("Field 'secretKey' is not allowed for filtering");
+  }
+
+  @Test
+  void shouldRejectDisallowedSortField() {
+    AllowedFieldsPolicy policy = AllowedFieldsPolicy.of(Set.of("name"), Set.of("name"));
+    GroupCondition rootCondition = new GroupCondition(LogicalOperator.AND, List.of());
+    QueryPlan<Object> plan = plan(rootCondition, Sort.by("internalScore"), policy);
+
+    assertThatExceptionOfType(DisallowedFieldException.class)
+        .isThrownBy(() -> factory.create(plan))
+        .withMessage("Field 'internalScore' is not allowed for sorting");
+  }
+
+  @Test
+  void shouldAllowWhitelistedFields() {
+    AllowedFieldsPolicy policy = AllowedFieldsPolicy.of(Set.of("name"), Set.of("name"));
+
+    Path<?> namePath = mock(Path.class);
+    doReturn(String.class).when(namePath).getJavaType();
+    doReturn(namePath).when(pathResolver).resolve(eq(root), any(), eq("name"), eq(JoinMode.LEFT));
+    when(valueConversionService.convert("Borja", String.class, Operators.EQUALS))
+        .thenReturn("Borja");
+
+    Predicate p1 = mock(Predicate.class);
+    Predicate combined = mock(Predicate.class);
+    OperatorHandler eqHandler = mock(OperatorHandler.class);
+    when(operatorRegistry.get(Operators.EQUALS)).thenReturn(eqHandler);
+    when(eqHandler.create(any(OperatorContext.class))).thenReturn(p1);
+    when(cb.and(any(Predicate[].class))).thenReturn(combined);
+
+    PredicateCondition c1 = new PredicateCondition("name", Operators.EQUALS, "Borja", false, false);
+    GroupCondition rootCondition = new GroupCondition(LogicalOperator.AND, List.of(c1));
+    QueryPlan<Object> plan = plan(rootCondition, Sort.by("name"), policy);
+
+    Specification<Object> spec = factory.create(plan);
+    Predicate result = spec.toPredicate(root, query, cb);
+
+    assertThat(result).isSameAs(combined);
+  }
+
+  @Test
+  void shouldAllowWhitelistedFieldsInNestedGroup() {
+    AllowedFieldsPolicy policy = AllowedFieldsPolicy.of(Set.of("name"), Set.of("name"));
+
+    Path<?> namePath = mock(Path.class);
+    doReturn(String.class).when(namePath).getJavaType();
+    doReturn(namePath).when(pathResolver).resolve(eq(root), any(), eq("name"), eq(JoinMode.LEFT));
+    when(valueConversionService.convert("Borja", String.class, Operators.EQUALS))
+        .thenReturn("Borja");
+
+    Predicate p1 = mock(Predicate.class);
+    Predicate innerCombined = mock(Predicate.class);
+    Predicate outerCombined = mock(Predicate.class);
+    OperatorHandler eqHandler = mock(OperatorHandler.class);
+    when(operatorRegistry.get(Operators.EQUALS)).thenReturn(eqHandler);
+    when(eqHandler.create(any(OperatorContext.class))).thenReturn(p1);
+    when(cb.or(any(Predicate[].class))).thenReturn(innerCombined);
+    when(cb.and(any(Predicate[].class))).thenReturn(outerCombined);
+
+    PredicateCondition c1 = new PredicateCondition("name", Operators.EQUALS, "Borja", false, false);
+    GroupCondition nested = new GroupCondition(LogicalOperator.OR, List.of(c1));
+    GroupCondition rootCondition =
+        new GroupCondition(LogicalOperator.AND, List.of((QueryCondition) nested));
+    QueryPlan<Object> plan = plan(rootCondition, Sort.unsorted(), policy);
+
+    Specification<Object> spec = factory.create(plan);
+    Predicate result = spec.toPredicate(root, query, cb);
+
+    assertThat(result).isSameAs(outerCombined);
+  }
+
+  @Test
+  void shouldRejectDisallowedFieldInNestedGroup() {
+    AllowedFieldsPolicy policy = AllowedFieldsPolicy.of(Set.of("name"), Set.of("name"));
+    PredicateCondition c1 =
+        new PredicateCondition("secret", Operators.EQUALS, "value", false, false);
+    GroupCondition nested = new GroupCondition(LogicalOperator.OR, List.of(c1));
+    GroupCondition rootCondition =
+        new GroupCondition(LogicalOperator.AND, List.of((QueryCondition) nested));
+    QueryPlan<Object> plan = plan(rootCondition, Sort.unsorted(), policy);
+
+    assertThatExceptionOfType(DisallowedFieldException.class)
+        .isThrownBy(() -> factory.create(plan))
+        .withMessage("Field 'secret' is not allowed for filtering");
+  }
+
+  @Test
+  void shouldPassValidationWithRestrictedPolicyAndNoSortOrConditions() {
+    AllowedFieldsPolicy policy = AllowedFieldsPolicy.of(Set.of("name"), Set.of("name"));
+    GroupCondition rootCondition = new GroupCondition(LogicalOperator.AND, List.of());
+    QueryPlan<Object> plan = plan(rootCondition, Sort.unsorted(), policy);
+
+    Specification<Object> spec = factory.create(plan);
+    Predicate result = spec.toPredicate(root, query, cb);
+
+    assertThat(result).isNull();
+  }
+
   private QueryPlan<Object> plan(GroupCondition rootCondition) {
+    return plan(rootCondition, Sort.unsorted(), AllowedFieldsPolicy.allowAll());
+  }
+
+  private QueryPlan<Object> plan(
+      GroupCondition rootCondition, Sort sort, AllowedFieldsPolicy policy) {
     return new QueryPlan<>(
         Object.class,
         rootCondition,
@@ -421,7 +545,8 @@ class QueryPlanSpecificationFactoryTest {
         List.of(),
         null,
         List.of(),
-        Sort.unsorted(),
-        false);
+        sort,
+        false,
+        policy);
   }
 }


### PR DESCRIPTION
## Summary

- Add `AllowedFieldsPolicy` with per-query field whitelisting for filtering and sorting
- `DisallowedFieldException` provides clear error messages with field name and usage context
- Validation runs in `QueryPlanSpecificationFactory.create()` before building the JPA Specification
- No global configuration needed — policy is set per-query via `allowedFields()` in the fluent API

### Usage

```java
var policy = AllowedFieldsPolicy.of(
    Set.of("name", "email"),   // allowed for filtering
    Set.of("name"));           // allowed for sorting

repository.query()
    .allowedFields(policy)
    .where("name", EQ, "John")
    .sort(Sort.by("name"))
    .findAll();

// Without policy = no restrictions (default)
repository.query().where("name", EQ, "John").findAll();
```

Closes #21

## Test plan

- [x] `./gradlew quality` passes (tests + 100% coverage + formatting)
- [x] Verify allowed fields pass validation
- [x] Verify disallowed filter fields throw `DisallowedFieldException`
- [x] Verify disallowed sort fields throw `DisallowedFieldException`
- [x] Verify nested condition groups are validated recursively
- [x] Verify default behavior (no policy) remains unchanged