### PR TITLE
feat(http): add HTTP filter parser module (#22)

### DIFF
--- a/README.md
+++ b/README.md
@@ -605,9 +605,11 @@ Important notes:
 ## HTTP Filter Parser
 
 The optional `specification-repository-http` module translates HTTP query parameters into a
-`QueryPlan` so controllers do not need hand-written parsing code. It depends only on
-`specification-repository-core` and exposes a Spring MVC argument resolver that is auto-configured
-when Spring Web is on the classpath. Works with both Spring Boot 3 and Spring Boot 4.
+`QueryPlan` so controllers do not need hand-written parsing code. The parser logic is plain Java,
+but the module's public API uses Spring Data Commons types such as `Sort`, so the minimal
+required dependencies include `specification-repository-core` and Spring Data Commons. It also
+exposes a Spring MVC argument resolver that is auto-configured when Spring Web is on the
+classpath. Works with both Spring Boot 3 and Spring Boot 4.
 
 **Gradle**
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Extensible Spring Data JPA query library with a fluent DSL and native-friendly a
 | `specification-repository-jpa` | JPA compiler, repository implementation, and metamodel path resolution |
 | `specification-repository-boot3-starter` | Spring Boot 3 auto-configuration |
 | `specification-repository-boot4-starter` | Spring Boot 4 auto-configuration |
+| `specification-repository-http` | Optional HTTP query parameter parser and Spring MVC argument resolver |
 | `specification-repository-test-support` | Shared test fixtures and utilities |
 | `examples` | Runnable sample applications |
 
@@ -601,6 +602,115 @@ Important notes:
 - custom `ValueConverter` beans are registered before the defaults, so domain-specific conversion can win first
 - providing a `SpecificationRepositoryConfiguration` bean replaces the starter-assembled configuration entirely
 
+## HTTP Filter Parser
+
+The optional `specification-repository-http` module translates HTTP query parameters into a
+`QueryPlan` so controllers do not need hand-written parsing code. It depends only on
+`specification-repository-core` and exposes a Spring MVC argument resolver that is auto-configured
+when Spring Web is on the classpath. Works with both Spring Boot 3 and Spring Boot 4.
+
+**Gradle**
+
+```kotlin
+implementation("com.borjaglez:specification-repository-http:0.1.0")
+```
+
+### Query Parameter Contract
+
+```
+GET /api/products?filter=name:contains:Laptop&filter=status:eq:ACTIVE
+                 &orFilter=price:lt:100;price:gt:1000
+                 &sort=price,desc&sort=name,asc
+                 &page=0&size=20
+```
+
+- **Filters**: `filter=field:operator:value` (repeatable, AND-combined at the root level). Operator
+  names reuse the existing `Operators` string values (`eq`, `neq`, `contains`, `startswith`,
+  `endswith`, `gt`, `gte`, `lt`, `lte`, `between`, `in`, `notin`, `isnull`, `isnotnull`, `isempty`,
+  `isnotempty`, `notcontains`).
+- **Multi-value operators** (`in`, `notin`, `between`): pipe-separated values — `status:in:ACTIVE|PENDING`,
+  `price:between:10|100`.
+- **Valueless operators** (`isnull`, `isnotnull`, `isempty`, `isnotempty`): value omitted —
+  `description:isnull`.
+- **OR groups**: `orFilter=field:op:val;field:op:val` — semicolon-separated filters inside a single
+  OR group. Repeatable for multiple independent groups.
+- **Sorting**: `sort=field,direction` (repeatable; direction is `asc` or `desc`, default `asc`).
+- **Pagination**: handled by Spring's standard `Pageable` resolver — this module does not parse
+  `page`/`size`.
+
+Field names are validated against a strict pattern (`[a-zA-Z][a-zA-Z0-9_]*` with optional dotted
+segments), so paths like `../../secret` are rejected as syntax errors.
+
+### Spring MVC Controller Usage
+
+Annotate a `QueryPlan<T>` controller parameter with `@FilterableQuery` and let the argument
+resolver build and whitelist the plan from the request:
+
+```java
+@RestController
+@RequestMapping("/api/products")
+public class ProductController {
+
+    @GetMapping("/filter")
+    public Page<Product> filter(
+            @FilterableQuery(
+                    value = Product.class,
+                    filterableFields = {"name", "status", "price", "category.name", "createdAt"},
+                    sortableFields = {"name", "price", "createdAt"})
+                    QueryPlan<Product> query,
+            Pageable pageable) {
+        return productRepository.findAll(query, pageable);
+    }
+}
+```
+
+`filterableFields` and `sortableFields` are translated into an `AllowedFieldsPolicy`, so any
+client attempting to filter or sort by a non-whitelisted field receives a `DisallowedFieldException`.
+
+### Programmatic Usage (no Spring)
+
+The parser is a pure Java class and can be used outside of Spring MVC:
+
+```java
+HttpFilterParser parser = new HttpFilterParser();
+
+Map<String, List<String>> params = Map.of(
+        "filter", List.of("name:contains:Laptop", "status:eq:ACTIVE"),
+        "sort",   List.of("price,desc"));
+
+QueryPlan<Product> plan = parser.toQueryPlan(Product.class, params);
+List<Product> products = productRepository.findAll(plan);
+```
+
+`HttpFilterParserConfiguration` lets you customize parameter names, separators, limits, and an
+optional allowed-operators set:
+
+```java
+HttpFilterParserConfiguration config = HttpFilterParserConfiguration.builder()
+        .filterParam("q")
+        .orFilterParam("any")
+        .sortParam("order")
+        .multiValueSeparator(",")
+        .orGroupSeparator("|")
+        .maxFilters(10)
+        .maxSortFields(3)
+        .allowedOperators(Set.of("eq", "contains", "in"))
+        .build();
+
+HttpFilterParser parser = new HttpFilterParser(config);
+```
+
+### Error Handling
+
+- `HttpFilterSyntaxException` — thrown for malformed filter/sort expressions, invalid field
+  names, and filter/sort count limits exceeded.
+- `HttpUnknownOperatorException` — thrown when the operator is not in the configured
+  `allowedOperators` set.
+
+Both extend `IllegalArgumentException` and propagate to the caller so applications can map them
+to HTTP 400 responses via their preferred error handling strategy (`@ControllerAdvice`,
+`ProblemDetail`, etc.). The module does not register its own exception handler.
+
 ## Demo Applications
 
 The repository includes four demo applications:
@@ -619,6 +729,12 @@ Example aggregate endpoint available in every demo application:
 
 ```text
 GET /api/products/aggregates/active-summary
+```
+
+The Boot 3 H2 demo also exposes the HTTP filter parser via `@FilterableQuery`:
+
+```text
+GET /api/products/filter?filter=name:contains:Laptop&filter=status:eq:ACTIVE&sort=price,desc&page=0&size=20
 ```
 
 That endpoint demonstrates:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,6 +14,7 @@ tasks.register("coverage") {
     dependsOn(
         ":specification-repository-core:jacocoTestCoverageVerification",
         ":specification-repository-jpa:jacocoTestCoverageVerification",
+        ":specification-repository-http:jacocoTestCoverageVerification",
         ":specification-repository-boot3-starter:jacocoTestCoverageVerification",
         ":specification-repository-boot4-starter:jacocoTestCoverageVerification",
         ":specification-repository-test-support:test"
@@ -26,6 +27,7 @@ tasks.register("quality") {
     dependsOn(
         ":specification-repository-core:test",
         ":specification-repository-jpa:test",
+        ":specification-repository-http:test",
         ":specification-repository-boot3-starter:test",
         ":specification-repository-boot4-starter:test",
         ":specification-repository-test-support:test",
@@ -60,6 +62,7 @@ tasks.register("spotlessCheckAll") {
     dependsOn(
         ":specification-repository-core:spotlessCheck",
         ":specification-repository-jpa:spotlessCheck",
+        ":specification-repository-http:spotlessCheck",
         ":specification-repository-boot3-starter:spotlessCheck",
         ":specification-repository-boot4-starter:spotlessCheck",
         ":specification-repository-test-support:spotlessCheck",
@@ -76,6 +79,7 @@ tasks.register("spotlessApplyAll") {
     dependsOn(
         ":specification-repository-core:spotlessApply",
         ":specification-repository-jpa:spotlessApply",
+        ":specification-repository-http:spotlessApply",
         ":specification-repository-boot3-starter:spotlessApply",
         ":specification-repository-boot4-starter:spotlessApply",
         ":specification-repository-test-support:spotlessApply",

--- a/examples/boot3-demo/build.gradle.kts
+++ b/examples/boot3-demo/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
 
 dependencies {
     implementation(project(":specification-repository-boot3-starter"))
+    implementation(project(":specification-repository-http"))
     implementation(libs.spring.boot.starter.web)
     implementation(libs.spring.boot.starter.data.jpa)
     developmentOnly(libs.spring.boot.devtools)

--- a/examples/boot3-demo/src/main/java/com/borjaglez/specrepository/examples/boot3/controller/ProductController.java
+++ b/examples/boot3-demo/src/main/java/com/borjaglez/specrepository/examples/boot3/controller/ProductController.java
@@ -3,12 +3,15 @@ package com.borjaglez.specrepository.examples.boot3.controller;
 import java.util.List;
 
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import com.borjaglez.specrepository.core.QueryPlan;
 import com.borjaglez.specrepository.examples.boot3.entity.Product;
 import com.borjaglez.specrepository.examples.boot3.service.ProductAggregateSummaryResponse;
 import com.borjaglez.specrepository.examples.boot3.service.ProductService;
+import com.borjaglez.specrepository.http.spring.FilterableQuery;
 
 @RestController
 @RequestMapping("/api/products")
@@ -126,5 +129,23 @@ public class ProductController {
   @GetMapping("/count/grouped-by-category")
   public long countGroupedByCategory() {
     return productService.countGroupedByCategory();
+  }
+
+  @GetMapping("/filter")
+  public Page<Product> filter(
+      @FilterableQuery(
+              value = Product.class,
+              filterableFields = {
+                "name",
+                "status",
+                "price",
+                "description",
+                "category.name",
+                "createdAt"
+              },
+              sortableFields = {"name", "price", "createdAt"})
+          QueryPlan<Product> query,
+      Pageable pageable) {
+    return productService.findByQueryPlan(query, pageable);
   }
 }

--- a/examples/boot3-demo/src/main/java/com/borjaglez/specrepository/examples/boot3/service/ProductService.java
+++ b/examples/boot3-demo/src/main/java/com/borjaglez/specrepository/examples/boot3/service/ProductService.java
@@ -6,11 +6,13 @@ import java.util.Optional;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.borjaglez.specrepository.core.Operators;
+import com.borjaglez.specrepository.core.QueryPlan;
 import com.borjaglez.specrepository.examples.boot3.entity.Product;
 import com.borjaglez.specrepository.examples.boot3.repository.ProductRepository;
 
@@ -216,6 +218,11 @@ public class ProductService {
   /** Grouped count: number of distinct categories with products. */
   public long countGroupedByCategory() {
     return productRepository.query().groupBy("category.name").count();
+  }
+
+  /** Execute a pre-built QueryPlan from HTTP filter parsing. */
+  public Page<Product> findByQueryPlan(QueryPlan<Product> queryPlan, Pageable pageable) {
+    return productRepository.findAll(queryPlan, pageable);
   }
 
   private static BigDecimal toBigDecimal(Optional<?> value) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -30,6 +30,8 @@ spring-data-commons = { module = "org.springframework.data:spring-data-commons",
 spring-data-jpa = { module = "org.springframework.data:spring-data-jpa", version.ref = "spring-data" }
 spring-context = { module = "org.springframework:spring-context", version.ref = "spring-framework" }
 spring-core = { module = "org.springframework:spring-core", version.ref = "spring-framework" }
+spring-web = { module = "org.springframework:spring-web", version.ref = "spring-framework" }
+spring-webmvc = { module = "org.springframework:spring-webmvc", version.ref = "spring-framework" }
 jakarta-persistence-api = { module = "jakarta.persistence:jakarta.persistence-api", version.ref = "jakarta-persistence" }
 
 spring-boot4-autoconfigure = { module = "org.springframework.boot:spring-boot-autoconfigure", version.ref = "spring-boot4" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -20,6 +20,7 @@ rootProject.name = "spring-boot-specification-repository"
 include(
     ":specification-repository-core",
     ":specification-repository-jpa",
+    ":specification-repository-http",
     ":specification-repository-boot3-starter",
     ":specification-repository-boot4-starter",
     ":specification-repository-test-support",

--- a/specification-repository-http/build.gradle.kts
+++ b/specification-repository-http/build.gradle.kts
@@ -1,0 +1,21 @@
+plugins {
+    id("specification-library-conventions")
+    id("specification-publish-conventions")
+}
+
+dependencies {
+    api(project(":specification-repository-core"))
+    compileOnlyApi(platform("org.springframework.boot:spring-boot-dependencies:${libs.versions.spring.boot.get()}"))
+    compileOnlyApi(libs.spring.web)
+    compileOnlyApi(libs.spring.webmvc)
+    compileOnlyApi(libs.spring.boot.autoconfigure)
+    annotationProcessor(platform("org.springframework.boot:spring-boot-dependencies:${libs.versions.spring.boot.get()}"))
+    annotationProcessor(libs.spring.boot.configuration.processor)
+    testImplementation(platform("org.springframework.boot:spring-boot-dependencies:${libs.versions.spring.boot.get()}"))
+    testImplementation(libs.spring.data.commons)
+    testImplementation(libs.spring.web)
+    testImplementation(libs.spring.webmvc)
+    testImplementation(libs.spring.boot.autoconfigure)
+    testImplementation(libs.spring.boot.starter.test)
+    testImplementation(libs.spring.boot.starter.web)
+}

--- a/specification-repository-http/src/main/java/com/borjaglez/specrepository/http/HttpFilterParser.java
+++ b/specification-repository-http/src/main/java/com/borjaglez/specrepository/http/HttpFilterParser.java
@@ -157,7 +157,14 @@ public final class HttpFilterParser {
       throw new HttpFilterSyntaxException(raw, "value is required for operator '" + operator + "'");
     }
     if (MULTI_VALUE_OPERATORS.contains(lowerOp)) {
-      return Arrays.asList(rawValue.split(Pattern.quote(config.multiValueSeparator()), -1));
+      List<String> values =
+          Arrays.asList(rawValue.split(Pattern.quote(config.multiValueSeparator()), -1));
+      if ("between".equals(lowerOp)
+          && (values.size() != 2 || values.get(0).isEmpty() || values.get(1).isEmpty())) {
+        throw new HttpFilterSyntaxException(
+            raw, "operator '" + operator + "' requires exactly 2 non-empty values");
+      }
+      return values;
     }
     return rawValue;
   }

--- a/specification-repository-http/src/main/java/com/borjaglez/specrepository/http/HttpFilterParser.java
+++ b/specification-repository-http/src/main/java/com/borjaglez/specrepository/http/HttpFilterParser.java
@@ -1,0 +1,227 @@
+package com.borjaglez.specrepository.http;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+import org.springframework.data.domain.Sort;
+
+import com.borjaglez.specrepository.core.AllowedFieldsPolicy;
+import com.borjaglez.specrepository.core.FilterOperator;
+import com.borjaglez.specrepository.core.QueryPlan;
+import com.borjaglez.specrepository.core.QueryPlanBuilder;
+import com.borjaglez.specrepository.core.SpecificationQueryBuilder;
+import com.borjaglez.specrepository.http.ParsedHttpQuery.ParsedFilter;
+import com.borjaglez.specrepository.http.ParsedHttpQuery.ParsedOrGroup;
+
+public final class HttpFilterParser {
+
+  private static final Pattern SAFE_FIELD_NAME =
+      Pattern.compile("[a-zA-Z][a-zA-Z0-9_]*(\\.[a-zA-Z][a-zA-Z0-9_]*)*");
+
+  private static final Set<String> VALUELESS_OPERATORS =
+      Set.of("isnull", "isnotnull", "isempty", "isnotempty");
+
+  private static final Set<String> MULTI_VALUE_OPERATORS = Set.of("in", "notin", "between");
+
+  private final HttpFilterParserConfiguration config;
+
+  public HttpFilterParser() {
+    this(HttpFilterParserConfiguration.defaults());
+  }
+
+  public HttpFilterParser(HttpFilterParserConfiguration config) {
+    this.config = Objects.requireNonNull(config, "config must not be null");
+  }
+
+  public ParsedHttpQuery parse(Map<String, List<String>> params) {
+    Objects.requireNonNull(params, "params must not be null");
+    List<ParsedFilter> filters = parseFilters(params);
+    List<ParsedOrGroup> orGroups = parseOrGroups(params);
+    Sort sort = parseSort(params);
+    return new ParsedHttpQuery(filters, orGroups, sort);
+  }
+
+  public <T> QueryPlanBuilder<T> applyTo(
+      QueryPlanBuilder<T> builder, Map<String, List<String>> params) {
+    Objects.requireNonNull(builder, "builder must not be null");
+    ParsedHttpQuery parsed = parse(params);
+    return applyParsed(builder, parsed);
+  }
+
+  public <T> QueryPlan<T> toQueryPlan(Class<T> entityType, Map<String, List<String>> params) {
+    Objects.requireNonNull(entityType, "entityType must not be null");
+    ParsedHttpQuery parsed = parse(params);
+    QueryPlanBuilder<T> builder = SpecificationQueryBuilder.forEntity(entityType);
+    return applyParsed(builder, parsed).build();
+  }
+
+  public <T> QueryPlan<T> toQueryPlan(
+      Class<T> entityType, Map<String, List<String>> params, AllowedFieldsPolicy policy) {
+    Objects.requireNonNull(entityType, "entityType must not be null");
+    Objects.requireNonNull(policy, "policy must not be null");
+    ParsedHttpQuery parsed = parse(params);
+    QueryPlanBuilder<T> builder = SpecificationQueryBuilder.forEntity(entityType);
+    return applyParsed(builder, parsed).allowedFields(policy).build();
+  }
+
+  private <T> QueryPlanBuilder<T> applyParsed(QueryPlanBuilder<T> builder, ParsedHttpQuery parsed) {
+    for (ParsedFilter filter : parsed.filters()) {
+      builder.where(filter.field(), filter.operator(), filter.value());
+    }
+    for (ParsedOrGroup orGroup : parsed.orGroups()) {
+      builder.or(
+          g -> {
+            for (ParsedFilter filter : orGroup.filters()) {
+              g.where(filter.field(), filter.operator(), filter.value());
+            }
+          });
+    }
+    if (parsed.sort().isSorted()) {
+      builder.sort(parsed.sort());
+    }
+    return builder;
+  }
+
+  private List<ParsedFilter> parseFilters(Map<String, List<String>> params) {
+    List<String> values = params.getOrDefault(config.filterParam(), Collections.emptyList());
+    validateFilterCount(values.size());
+    List<ParsedFilter> filters = new ArrayList<>();
+    for (String raw : values) {
+      filters.add(parseFilterExpression(raw));
+    }
+    return filters;
+  }
+
+  private List<ParsedOrGroup> parseOrGroups(Map<String, List<String>> params) {
+    List<String> values = params.getOrDefault(config.orFilterParam(), Collections.emptyList());
+    List<ParsedOrGroup> groups = new ArrayList<>();
+    int totalFilterCount =
+        params.getOrDefault(config.filterParam(), Collections.emptyList()).size();
+    for (String raw : values) {
+      String[] parts = raw.split(Pattern.quote(config.orGroupSeparator()), -1);
+      totalFilterCount += parts.length;
+      validateFilterCount(totalFilterCount);
+      List<ParsedFilter> filters = new ArrayList<>();
+      for (String part : parts) {
+        filters.add(parseFilterExpression(part));
+      }
+      groups.add(new ParsedOrGroup(filters));
+    }
+    return groups;
+  }
+
+  private ParsedFilter parseFilterExpression(String raw) {
+    if (raw.isEmpty()) {
+      throw new HttpFilterSyntaxException(raw, "expression must not be empty");
+    }
+    int firstColon = raw.indexOf(':');
+    if (firstColon < 1) {
+      throw new HttpFilterSyntaxException(raw, "missing field name or operator separator");
+    }
+    String field = raw.substring(0, firstColon);
+    validateFieldName(raw, field);
+    String rest = raw.substring(firstColon + 1);
+
+    String operator;
+    String rawValue;
+    int secondColon = rest.indexOf(':');
+    if (secondColon < 0) {
+      operator = rest;
+      rawValue = null;
+    } else {
+      operator = rest.substring(0, secondColon);
+      rawValue = rest.substring(secondColon + 1);
+    }
+
+    if (operator.isEmpty()) {
+      throw new HttpFilterSyntaxException(raw, "operator must not be empty");
+    }
+    validateOperator(operator);
+
+    Object value = resolveValue(raw, operator, rawValue);
+    return new ParsedFilter(field, FilterOperator.of(operator), value);
+  }
+
+  private Object resolveValue(String raw, String operator, String rawValue) {
+    String lowerOp = operator.toLowerCase();
+    if (VALUELESS_OPERATORS.contains(lowerOp)) {
+      return null;
+    }
+    if (rawValue == null || rawValue.isEmpty()) {
+      throw new HttpFilterSyntaxException(raw, "value is required for operator '" + operator + "'");
+    }
+    if (MULTI_VALUE_OPERATORS.contains(lowerOp)) {
+      return Arrays.asList(rawValue.split(Pattern.quote(config.multiValueSeparator()), -1));
+    }
+    return rawValue;
+  }
+
+  private Sort parseSort(Map<String, List<String>> params) {
+    List<String> values = params.getOrDefault(config.sortParam(), Collections.emptyList());
+    if (values.isEmpty()) {
+      return Sort.unsorted();
+    }
+    if (values.size() > config.maxSortFields()) {
+      throw new HttpFilterSyntaxException(
+          String.join(", ", values), "too many sort fields (max " + config.maxSortFields() + ")");
+    }
+    List<Sort.Order> orders = new ArrayList<>();
+    for (String raw : values) {
+      orders.add(parseSortExpression(raw));
+    }
+    return Sort.by(orders);
+  }
+
+  private Sort.Order parseSortExpression(String raw) {
+    if (raw.isEmpty()) {
+      throw new HttpFilterSyntaxException(raw, "sort expression must not be empty");
+    }
+    String[] parts = raw.split(",", -1);
+    if (parts.length > 2) {
+      throw new HttpFilterSyntaxException(
+          raw, "sort expression must have at most 2 parts (field,direction)");
+    }
+    String field = parts[0].trim();
+    if (field.isEmpty()) {
+      throw new HttpFilterSyntaxException(raw, "sort field must not be empty");
+    }
+    validateFieldName(raw, field);
+    if (parts.length == 1) {
+      return Sort.Order.asc(field);
+    }
+    String direction = parts[1].trim().toLowerCase();
+    return switch (direction) {
+      case "asc" -> Sort.Order.asc(field);
+      case "desc" -> Sort.Order.desc(field);
+      default ->
+          throw new HttpFilterSyntaxException(
+              raw, "invalid sort direction '" + parts[1].trim() + "' (expected 'asc' or 'desc')");
+    };
+  }
+
+  private void validateOperator(String operator) {
+    Set<String> allowed = config.allowedOperators();
+    if (allowed != null && !allowed.contains(operator.toLowerCase())) {
+      throw new HttpUnknownOperatorException(operator);
+    }
+  }
+
+  private void validateFieldName(String raw, String field) {
+    if (!SAFE_FIELD_NAME.matcher(field).matches()) {
+      throw new HttpFilterSyntaxException(raw, "invalid field name '" + field + "'");
+    }
+  }
+
+  private void validateFilterCount(int count) {
+    if (count > config.maxFilters()) {
+      throw new HttpFilterSyntaxException(
+          count + " filters", "too many filters (max " + config.maxFilters() + ")");
+    }
+  }
+}

--- a/specification-repository-http/src/main/java/com/borjaglez/specrepository/http/HttpFilterParserConfiguration.java
+++ b/specification-repository-http/src/main/java/com/borjaglez/specrepository/http/HttpFilterParserConfiguration.java
@@ -1,7 +1,9 @@
 package com.borjaglez.specrepository.http;
 
+import java.util.Locale;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 public final class HttpFilterParserConfiguration {
   private final String filterParam;
@@ -22,7 +24,11 @@ public final class HttpFilterParserConfiguration {
     this.maxFilters = builder.maxFilters;
     this.maxSortFields = builder.maxSortFields;
     this.allowedOperators =
-        builder.allowedOperators == null ? null : Set.copyOf(builder.allowedOperators);
+        builder.allowedOperators == null
+            ? null
+            : builder.allowedOperators.stream()
+                .map(op -> op.toLowerCase(Locale.ROOT))
+                .collect(Collectors.toUnmodifiableSet());
   }
 
   public static HttpFilterParserConfiguration defaults() {

--- a/specification-repository-http/src/main/java/com/borjaglez/specrepository/http/HttpFilterParserConfiguration.java
+++ b/specification-repository-http/src/main/java/com/borjaglez/specrepository/http/HttpFilterParserConfiguration.java
@@ -1,0 +1,132 @@
+package com.borjaglez.specrepository.http;
+
+import java.util.Objects;
+import java.util.Set;
+
+public final class HttpFilterParserConfiguration {
+  private final String filterParam;
+  private final String orFilterParam;
+  private final String sortParam;
+  private final String multiValueSeparator;
+  private final String orGroupSeparator;
+  private final int maxFilters;
+  private final int maxSortFields;
+  private final Set<String> allowedOperators;
+
+  private HttpFilterParserConfiguration(Builder builder) {
+    this.filterParam = builder.filterParam;
+    this.orFilterParam = builder.orFilterParam;
+    this.sortParam = builder.sortParam;
+    this.multiValueSeparator = builder.multiValueSeparator;
+    this.orGroupSeparator = builder.orGroupSeparator;
+    this.maxFilters = builder.maxFilters;
+    this.maxSortFields = builder.maxSortFields;
+    this.allowedOperators =
+        builder.allowedOperators == null ? null : Set.copyOf(builder.allowedOperators);
+  }
+
+  public static HttpFilterParserConfiguration defaults() {
+    return builder().build();
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public String filterParam() {
+    return filterParam;
+  }
+
+  public String orFilterParam() {
+    return orFilterParam;
+  }
+
+  public String sortParam() {
+    return sortParam;
+  }
+
+  public String multiValueSeparator() {
+    return multiValueSeparator;
+  }
+
+  public String orGroupSeparator() {
+    return orGroupSeparator;
+  }
+
+  public int maxFilters() {
+    return maxFilters;
+  }
+
+  public int maxSortFields() {
+    return maxSortFields;
+  }
+
+  public Set<String> allowedOperators() {
+    return allowedOperators;
+  }
+
+  public static final class Builder {
+    private String filterParam = "filter";
+    private String orFilterParam = "orFilter";
+    private String sortParam = "sort";
+    private String multiValueSeparator = "|";
+    private String orGroupSeparator = ";";
+    private int maxFilters = 20;
+    private int maxSortFields = 5;
+    private Set<String> allowedOperators;
+
+    private Builder() {}
+
+    public Builder filterParam(String filterParam) {
+      this.filterParam = Objects.requireNonNull(filterParam, "filterParam must not be null");
+      return this;
+    }
+
+    public Builder orFilterParam(String orFilterParam) {
+      this.orFilterParam = Objects.requireNonNull(orFilterParam, "orFilterParam must not be null");
+      return this;
+    }
+
+    public Builder sortParam(String sortParam) {
+      this.sortParam = Objects.requireNonNull(sortParam, "sortParam must not be null");
+      return this;
+    }
+
+    public Builder multiValueSeparator(String multiValueSeparator) {
+      this.multiValueSeparator =
+          Objects.requireNonNull(multiValueSeparator, "multiValueSeparator must not be null");
+      return this;
+    }
+
+    public Builder orGroupSeparator(String orGroupSeparator) {
+      this.orGroupSeparator =
+          Objects.requireNonNull(orGroupSeparator, "orGroupSeparator must not be null");
+      return this;
+    }
+
+    public Builder maxFilters(int maxFilters) {
+      if (maxFilters < 1) {
+        throw new IllegalArgumentException("maxFilters must be at least 1");
+      }
+      this.maxFilters = maxFilters;
+      return this;
+    }
+
+    public Builder maxSortFields(int maxSortFields) {
+      if (maxSortFields < 1) {
+        throw new IllegalArgumentException("maxSortFields must be at least 1");
+      }
+      this.maxSortFields = maxSortFields;
+      return this;
+    }
+
+    public Builder allowedOperators(Set<String> allowedOperators) {
+      this.allowedOperators = allowedOperators;
+      return this;
+    }
+
+    public HttpFilterParserConfiguration build() {
+      return new HttpFilterParserConfiguration(this);
+    }
+  }
+}

--- a/specification-repository-http/src/main/java/com/borjaglez/specrepository/http/HttpFilterSyntaxException.java
+++ b/specification-repository-http/src/main/java/com/borjaglez/specrepository/http/HttpFilterSyntaxException.java
@@ -1,0 +1,20 @@
+package com.borjaglez.specrepository.http;
+
+public class HttpFilterSyntaxException extends IllegalArgumentException {
+  private final String rawExpression;
+  private final String reason;
+
+  public HttpFilterSyntaxException(String rawExpression, String reason) {
+    super("Invalid filter expression '" + rawExpression + "': " + reason);
+    this.rawExpression = rawExpression;
+    this.reason = reason;
+  }
+
+  public String rawExpression() {
+    return rawExpression;
+  }
+
+  public String reason() {
+    return reason;
+  }
+}

--- a/specification-repository-http/src/main/java/com/borjaglez/specrepository/http/HttpUnknownOperatorException.java
+++ b/specification-repository-http/src/main/java/com/borjaglez/specrepository/http/HttpUnknownOperatorException.java
@@ -1,0 +1,14 @@
+package com.borjaglez.specrepository.http;
+
+public class HttpUnknownOperatorException extends IllegalArgumentException {
+  private final String operator;
+
+  public HttpUnknownOperatorException(String operator) {
+    super("Unknown filter operator '" + operator + "'");
+    this.operator = operator;
+  }
+
+  public String operator() {
+    return operator;
+  }
+}

--- a/specification-repository-http/src/main/java/com/borjaglez/specrepository/http/ParsedHttpQuery.java
+++ b/specification-repository-http/src/main/java/com/borjaglez/specrepository/http/ParsedHttpQuery.java
@@ -1,0 +1,33 @@
+package com.borjaglez.specrepository.http;
+
+import java.util.List;
+import java.util.Objects;
+
+import org.springframework.data.domain.Sort;
+
+import com.borjaglez.specrepository.core.FilterOperator;
+
+public record ParsedHttpQuery(List<ParsedFilter> filters, List<ParsedOrGroup> orGroups, Sort sort) {
+
+  public ParsedHttpQuery {
+    Objects.requireNonNull(filters, "filters must not be null");
+    Objects.requireNonNull(orGroups, "orGroups must not be null");
+    Objects.requireNonNull(sort, "sort must not be null");
+    filters = List.copyOf(filters);
+    orGroups = List.copyOf(orGroups);
+  }
+
+  public record ParsedFilter(String field, FilterOperator operator, Object value) {
+    public ParsedFilter {
+      Objects.requireNonNull(field, "field must not be null");
+      Objects.requireNonNull(operator, "operator must not be null");
+    }
+  }
+
+  public record ParsedOrGroup(List<ParsedFilter> filters) {
+    public ParsedOrGroup {
+      Objects.requireNonNull(filters, "filters must not be null");
+      filters = List.copyOf(filters);
+    }
+  }
+}

--- a/specification-repository-http/src/main/java/com/borjaglez/specrepository/http/spring/FilterableQuery.java
+++ b/specification-repository-http/src/main/java/com/borjaglez/specrepository/http/spring/FilterableQuery.java
@@ -1,0 +1,18 @@
+package com.borjaglez.specrepository.http.spring;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface FilterableQuery {
+  Class<?> value();
+
+  String[] filterableFields() default {};
+
+  String[] sortableFields() default {};
+}

--- a/specification-repository-http/src/main/java/com/borjaglez/specrepository/http/spring/HttpFilterAutoConfiguration.java
+++ b/specification-repository-http/src/main/java/com/borjaglez/specrepository/http/spring/HttpFilterAutoConfiguration.java
@@ -1,0 +1,42 @@
+package com.borjaglez.specrepository.http.spring;
+
+import java.util.List;
+
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
+import org.springframework.context.annotation.Bean;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import com.borjaglez.specrepository.http.HttpFilterParser;
+
+@AutoConfiguration
+@ConditionalOnClass(HandlerMethodArgumentResolver.class)
+@ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.SERVLET)
+public class HttpFilterAutoConfiguration {
+
+  @Bean
+  @ConditionalOnMissingBean
+  HttpFilterParser httpFilterParser() {
+    return new HttpFilterParser();
+  }
+
+  @Bean
+  @ConditionalOnMissingBean
+  QueryPlanArgumentResolver queryPlanArgumentResolver(HttpFilterParser parser) {
+    return new QueryPlanArgumentResolver(parser);
+  }
+
+  @Bean
+  @ConditionalOnMissingBean(name = "httpFilterWebMvcConfigurer")
+  WebMvcConfigurer httpFilterWebMvcConfigurer(QueryPlanArgumentResolver resolver) {
+    return new WebMvcConfigurer() {
+      @Override
+      public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(resolver);
+      }
+    };
+  }
+}

--- a/specification-repository-http/src/main/java/com/borjaglez/specrepository/http/spring/QueryPlanArgumentResolver.java
+++ b/specification-repository-http/src/main/java/com/borjaglez/specrepository/http/spring/QueryPlanArgumentResolver.java
@@ -55,6 +55,8 @@ public class QueryPlanArgumentResolver implements HandlerMethodArgumentResolver 
     if (filterable.length == 0 && sortable.length == 0) {
       return AllowedFieldsPolicy.allowAll();
     }
-    return AllowedFieldsPolicy.of(Set.of(filterable), Set.of(sortable));
+    Set<String> filterableFields = Arrays.stream(filterable).collect(Collectors.toSet());
+    Set<String> sortableFields = Arrays.stream(sortable).collect(Collectors.toSet());
+    return AllowedFieldsPolicy.of(filterableFields, sortableFields);
   }
 }

--- a/specification-repository-http/src/main/java/com/borjaglez/specrepository/http/spring/QueryPlanArgumentResolver.java
+++ b/specification-repository-http/src/main/java/com/borjaglez/specrepository/http/spring/QueryPlanArgumentResolver.java
@@ -1,0 +1,60 @@
+package com.borjaglez.specrepository.http.spring;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import com.borjaglez.specrepository.core.AllowedFieldsPolicy;
+import com.borjaglez.specrepository.core.QueryPlan;
+import com.borjaglez.specrepository.http.HttpFilterParser;
+
+public class QueryPlanArgumentResolver implements HandlerMethodArgumentResolver {
+
+  private final HttpFilterParser parser;
+
+  public QueryPlanArgumentResolver(HttpFilterParser parser) {
+    this.parser = parser;
+  }
+
+  @Override
+  public boolean supportsParameter(MethodParameter parameter) {
+    return parameter.hasParameterAnnotation(FilterableQuery.class)
+        && QueryPlan.class.isAssignableFrom(parameter.getParameterType());
+  }
+
+  @Override
+  public Object resolveArgument(
+      MethodParameter parameter,
+      ModelAndViewContainer mavContainer,
+      NativeWebRequest webRequest,
+      WebDataBinderFactory binderFactory) {
+    FilterableQuery annotation = parameter.getParameterAnnotation(FilterableQuery.class);
+    Map<String, List<String>> params = extractParams(webRequest);
+    AllowedFieldsPolicy policy = buildPolicy(annotation);
+    return parser.toQueryPlan(annotation.value(), params, policy);
+  }
+
+  private Map<String, List<String>> extractParams(NativeWebRequest webRequest) {
+    return webRequest.getParameterMap().entrySet().stream()
+        .collect(
+            Collectors.toMap(Map.Entry::getKey, e -> new ArrayList<>(Arrays.asList(e.getValue()))));
+  }
+
+  private AllowedFieldsPolicy buildPolicy(FilterableQuery annotation) {
+    String[] filterable = annotation.filterableFields();
+    String[] sortable = annotation.sortableFields();
+    if (filterable.length == 0 && sortable.length == 0) {
+      return AllowedFieldsPolicy.allowAll();
+    }
+    return AllowedFieldsPolicy.of(Set.of(filterable), Set.of(sortable));
+  }
+}

--- a/specification-repository-http/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/specification-repository-http/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+com.borjaglez.specrepository.http.spring.HttpFilterAutoConfiguration

--- a/specification-repository-http/src/test/java/com/borjaglez/specrepository/http/HttpFilterParserConfigurationTest.java
+++ b/specification-repository-http/src/test/java/com/borjaglez/specrepository/http/HttpFilterParserConfigurationTest.java
@@ -92,6 +92,13 @@ class HttpFilterParserConfigurationTest {
   }
 
   @Test
+  void allowedOperatorsShouldBeNormalizedToLowerCase() {
+    var config =
+        HttpFilterParserConfiguration.builder().allowedOperators(Set.of("EQ", "Neq")).build();
+    assertThat(config.allowedOperators()).containsExactlyInAnyOrder("eq", "neq");
+  }
+
+  @Test
   void allowedOperatorsShouldBeImmutableCopy() {
     var operators = new java.util.HashSet<>(Set.of("eq", "neq"));
     var config = HttpFilterParserConfiguration.builder().allowedOperators(operators).build();

--- a/specification-repository-http/src/test/java/com/borjaglez/specrepository/http/HttpFilterParserConfigurationTest.java
+++ b/specification-repository-http/src/test/java/com/borjaglez/specrepository/http/HttpFilterParserConfigurationTest.java
@@ -1,0 +1,101 @@
+package com.borjaglez.specrepository.http;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+class HttpFilterParserConfigurationTest {
+
+  @Test
+  void defaultsShouldHaveExpectedValues() {
+    var config = HttpFilterParserConfiguration.defaults();
+
+    assertThat(config.filterParam()).isEqualTo("filter");
+    assertThat(config.orFilterParam()).isEqualTo("orFilter");
+    assertThat(config.sortParam()).isEqualTo("sort");
+    assertThat(config.multiValueSeparator()).isEqualTo("|");
+    assertThat(config.orGroupSeparator()).isEqualTo(";");
+    assertThat(config.maxFilters()).isEqualTo(20);
+    assertThat(config.maxSortFields()).isEqualTo(5);
+    assertThat(config.allowedOperators()).isNull();
+  }
+
+  @Test
+  void builderShouldOverrideAllValues() {
+    var config =
+        HttpFilterParserConfiguration.builder()
+            .filterParam("f")
+            .orFilterParam("of")
+            .sortParam("s")
+            .multiValueSeparator(",")
+            .orGroupSeparator("&")
+            .maxFilters(10)
+            .maxSortFields(3)
+            .allowedOperators(Set.of("eq", "neq"))
+            .build();
+
+    assertThat(config.filterParam()).isEqualTo("f");
+    assertThat(config.orFilterParam()).isEqualTo("of");
+    assertThat(config.sortParam()).isEqualTo("s");
+    assertThat(config.multiValueSeparator()).isEqualTo(",");
+    assertThat(config.orGroupSeparator()).isEqualTo("&");
+    assertThat(config.maxFilters()).isEqualTo(10);
+    assertThat(config.maxSortFields()).isEqualTo(3);
+    assertThat(config.allowedOperators()).containsExactlyInAnyOrder("eq", "neq");
+  }
+
+  @Test
+  void builderShouldRejectNullFilterParam() {
+    assertThatThrownBy(() -> HttpFilterParserConfiguration.builder().filterParam(null))
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  void builderShouldRejectNullOrFilterParam() {
+    assertThatThrownBy(() -> HttpFilterParserConfiguration.builder().orFilterParam(null))
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  void builderShouldRejectNullSortParam() {
+    assertThatThrownBy(() -> HttpFilterParserConfiguration.builder().sortParam(null))
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  void builderShouldRejectNullMultiValueSeparator() {
+    assertThatThrownBy(() -> HttpFilterParserConfiguration.builder().multiValueSeparator(null))
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  void builderShouldRejectNullOrGroupSeparator() {
+    assertThatThrownBy(() -> HttpFilterParserConfiguration.builder().orGroupSeparator(null))
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  void builderShouldRejectZeroMaxFilters() {
+    assertThatThrownBy(() -> HttpFilterParserConfiguration.builder().maxFilters(0))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("maxFilters must be at least 1");
+  }
+
+  @Test
+  void builderShouldRejectZeroMaxSortFields() {
+    assertThatThrownBy(() -> HttpFilterParserConfiguration.builder().maxSortFields(0))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("maxSortFields must be at least 1");
+  }
+
+  @Test
+  void allowedOperatorsShouldBeImmutableCopy() {
+    var operators = new java.util.HashSet<>(Set.of("eq", "neq"));
+    var config = HttpFilterParserConfiguration.builder().allowedOperators(operators).build();
+    operators.add("gt");
+    assertThat(config.allowedOperators()).containsExactlyInAnyOrder("eq", "neq");
+  }
+}

--- a/specification-repository-http/src/test/java/com/borjaglez/specrepository/http/HttpFilterParserTest.java
+++ b/specification-repository-http/src/test/java/com/borjaglez/specrepository/http/HttpFilterParserTest.java
@@ -237,6 +237,28 @@ class HttpFilterParserTest {
       var result = parser.parse(Map.of("filter", List.of("status:in:ACTIVE")));
       assertThat(result.filters().get(0).value()).isEqualTo(List.of("ACTIVE"));
     }
+
+    @Test
+    void shouldRejectBetweenWithWrongNumberOfValues() {
+      assertThatThrownBy(() -> parser.parse(Map.of("filter", List.of("price:between:10"))))
+          .isInstanceOf(HttpFilterSyntaxException.class)
+          .hasMessageContaining("requires exactly 2 non-empty values");
+
+      assertThatThrownBy(() -> parser.parse(Map.of("filter", List.of("price:between:10|20|30"))))
+          .isInstanceOf(HttpFilterSyntaxException.class)
+          .hasMessageContaining("requires exactly 2 non-empty values");
+    }
+
+    @Test
+    void shouldRejectBetweenWithEmptyBound() {
+      assertThatThrownBy(() -> parser.parse(Map.of("filter", List.of("price:between:|100"))))
+          .isInstanceOf(HttpFilterSyntaxException.class)
+          .hasMessageContaining("requires exactly 2 non-empty values");
+
+      assertThatThrownBy(() -> parser.parse(Map.of("filter", List.of("price:between:10|"))))
+          .isInstanceOf(HttpFilterSyntaxException.class)
+          .hasMessageContaining("requires exactly 2 non-empty values");
+    }
   }
 
   @Nested
@@ -400,6 +422,15 @@ class HttpFilterParserTest {
     void shouldAcceptAnyOperatorWhenAllowedOperatorsIsNull() {
       var result = parser.parse(Map.of("filter", List.of("name:customop:value")));
       assertThat(result.filters().get(0).operator()).isEqualTo(FilterOperator.of("customop"));
+    }
+
+    @Test
+    void shouldAcceptOperatorsConfiguredInUpperCase() {
+      var config = HttpFilterParserConfiguration.builder().allowedOperators(Set.of("EQ")).build();
+      var p = new HttpFilterParser(config);
+
+      var result = p.parse(Map.of("filter", List.of("name:eq:John")));
+      assertThat(result.filters()).hasSize(1);
     }
   }
 

--- a/specification-repository-http/src/test/java/com/borjaglez/specrepository/http/HttpFilterParserTest.java
+++ b/specification-repository-http/src/test/java/com/borjaglez/specrepository/http/HttpFilterParserTest.java
@@ -1,0 +1,609 @@
+package com.borjaglez.specrepository.http;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Sort;
+
+import com.borjaglez.specrepository.core.AllowedFieldsPolicy;
+import com.borjaglez.specrepository.core.FilterOperator;
+import com.borjaglez.specrepository.core.LogicalOperator;
+import com.borjaglez.specrepository.core.Operators;
+import com.borjaglez.specrepository.core.PredicateCondition;
+import com.borjaglez.specrepository.core.QueryPlan;
+import com.borjaglez.specrepository.core.QueryPlanBuilder;
+import com.borjaglez.specrepository.core.SpecificationQueryBuilder;
+
+class HttpFilterParserTest {
+
+  private final HttpFilterParser parser = new HttpFilterParser();
+
+  // Dummy entity for QueryPlan tests
+  static class TestEntity {}
+
+  @Nested
+  class ConstructorTests {
+
+    @Test
+    void shouldCreateWithDefaults() {
+      var p = new HttpFilterParser();
+      var result = p.parse(Map.of());
+      assertThat(result.filters()).isEmpty();
+    }
+
+    @Test
+    void shouldRejectNullConfig() {
+      assertThatThrownBy(() -> new HttpFilterParser(null)).isInstanceOf(NullPointerException.class);
+    }
+  }
+
+  @Nested
+  class FilterParsingTests {
+
+    @Test
+    void shouldParseSingleEqualsFilter() {
+      var result = parser.parse(Map.of("filter", List.of("name:eq:John")));
+
+      assertThat(result.filters()).hasSize(1);
+      var f = result.filters().get(0);
+      assertThat(f.field()).isEqualTo("name");
+      assertThat(f.operator()).isEqualTo(Operators.EQUALS);
+      assertThat(f.value()).isEqualTo("John");
+    }
+
+    @Test
+    void shouldParseMultipleFilters() {
+      var result = parser.parse(Map.of("filter", List.of("name:eq:John", "status:neq:INACTIVE")));
+
+      assertThat(result.filters()).hasSize(2);
+      assertThat(result.filters().get(0).field()).isEqualTo("name");
+      assertThat(result.filters().get(1).field()).isEqualTo("status");
+    }
+
+    @Test
+    void shouldParseNestedPathFilter() {
+      var result = parser.parse(Map.of("filter", List.of("category.name:contains:Electronics")));
+
+      assertThat(result.filters().get(0).field()).isEqualTo("category.name");
+      assertThat(result.filters().get(0).operator()).isEqualTo(Operators.CONTAINS);
+    }
+
+    @Test
+    void shouldParseValueWithColons() {
+      var result = parser.parse(Map.of("filter", List.of("url:eq:http://example.com:8080")));
+
+      assertThat(result.filters().get(0).value()).isEqualTo("http://example.com:8080");
+    }
+
+    @Test
+    void shouldReturnEmptyFiltersWhenNoParams() {
+      var result = parser.parse(Map.of());
+
+      assertThat(result.filters()).isEmpty();
+      assertThat(result.orGroups()).isEmpty();
+      assertThat(result.sort()).isEqualTo(Sort.unsorted());
+    }
+
+    @Test
+    void shouldRejectNullParams() {
+      assertThatThrownBy(() -> parser.parse(null)).isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void shouldRejectEmptyExpression() {
+      assertThatThrownBy(() -> parser.parse(Map.of("filter", List.of(""))))
+          .isInstanceOf(HttpFilterSyntaxException.class)
+          .hasMessageContaining("expression must not be empty");
+    }
+
+    @Test
+    void shouldRejectMissingOperatorSeparator() {
+      assertThatThrownBy(() -> parser.parse(Map.of("filter", List.of("nameonly"))))
+          .isInstanceOf(HttpFilterSyntaxException.class)
+          .hasMessageContaining("missing field name or operator separator");
+    }
+
+    @Test
+    void shouldRejectEmptyFieldName() {
+      assertThatThrownBy(() -> parser.parse(Map.of("filter", List.of(":eq:value"))))
+          .isInstanceOf(HttpFilterSyntaxException.class)
+          .hasMessageContaining("missing field name or operator separator");
+    }
+
+    @Test
+    void shouldRejectInvalidFieldName() {
+      assertThatThrownBy(() -> parser.parse(Map.of("filter", List.of("../secret:eq:value"))))
+          .isInstanceOf(HttpFilterSyntaxException.class)
+          .hasMessageContaining("invalid field name");
+    }
+
+    @Test
+    void shouldRejectFieldNameStartingWithDot() {
+      assertThatThrownBy(() -> parser.parse(Map.of("filter", List.of(".field:eq:value"))))
+          .isInstanceOf(HttpFilterSyntaxException.class)
+          .hasMessageContaining("invalid field name");
+    }
+
+    @Test
+    void shouldRejectFieldNameWithDoubleDot() {
+      assertThatThrownBy(() -> parser.parse(Map.of("filter", List.of("a..b:eq:value"))))
+          .isInstanceOf(HttpFilterSyntaxException.class)
+          .hasMessageContaining("invalid field name");
+    }
+
+    @Test
+    void shouldRejectFieldNameWithSpecialChars() {
+      assertThatThrownBy(() -> parser.parse(Map.of("filter", List.of("na$me:eq:value"))))
+          .isInstanceOf(HttpFilterSyntaxException.class)
+          .hasMessageContaining("invalid field name");
+    }
+
+    @Test
+    void shouldRejectEmptyOperator() {
+      assertThatThrownBy(() -> parser.parse(Map.of("filter", List.of("name::value"))))
+          .isInstanceOf(HttpFilterSyntaxException.class)
+          .hasMessageContaining("operator must not be empty");
+    }
+
+    @Test
+    void shouldRejectMissingValueForNonValuelessOperator() {
+      assertThatThrownBy(() -> parser.parse(Map.of("filter", List.of("name:eq"))))
+          .isInstanceOf(HttpFilterSyntaxException.class)
+          .hasMessageContaining("value is required for operator 'eq'");
+    }
+
+    @Test
+    void shouldRejectEmptyValueForNonValuelessOperator() {
+      assertThatThrownBy(() -> parser.parse(Map.of("filter", List.of("name:eq:"))))
+          .isInstanceOf(HttpFilterSyntaxException.class)
+          .hasMessageContaining("value is required for operator 'eq'");
+    }
+  }
+
+  @Nested
+  class ValuelessOperatorTests {
+
+    @Test
+    void shouldParseIsNull() {
+      var result = parser.parse(Map.of("filter", List.of("description:isnull")));
+
+      assertThat(result.filters().get(0).operator()).isEqualTo(Operators.IS_NULL);
+      assertThat(result.filters().get(0).value()).isNull();
+    }
+
+    @Test
+    void shouldParseIsNotNull() {
+      var result = parser.parse(Map.of("filter", List.of("description:isnotnull")));
+      assertThat(result.filters().get(0).operator()).isEqualTo(Operators.IS_NOT_NULL);
+      assertThat(result.filters().get(0).value()).isNull();
+    }
+
+    @Test
+    void shouldParseIsEmpty() {
+      var result = parser.parse(Map.of("filter", List.of("tags:isempty")));
+      assertThat(result.filters().get(0).operator()).isEqualTo(Operators.IS_EMPTY);
+      assertThat(result.filters().get(0).value()).isNull();
+    }
+
+    @Test
+    void shouldParseIsNotEmpty() {
+      var result = parser.parse(Map.of("filter", List.of("tags:isnotempty")));
+      assertThat(result.filters().get(0).operator()).isEqualTo(Operators.IS_NOT_EMPTY);
+      assertThat(result.filters().get(0).value()).isNull();
+    }
+
+    @Test
+    void shouldIgnoreValueForValuelessOperator() {
+      var result = parser.parse(Map.of("filter", List.of("description:isnull:ignored")));
+      assertThat(result.filters().get(0).value()).isNull();
+    }
+  }
+
+  @Nested
+  class MultiValueOperatorTests {
+
+    @Test
+    void shouldParseInOperator() {
+      var result = parser.parse(Map.of("filter", List.of("status:in:ACTIVE|PENDING")));
+
+      assertThat(result.filters().get(0).operator()).isEqualTo(Operators.IN);
+      assertThat(result.filters().get(0).value()).isEqualTo(List.of("ACTIVE", "PENDING"));
+    }
+
+    @Test
+    void shouldParseNotInOperator() {
+      var result = parser.parse(Map.of("filter", List.of("status:notin:DELETED|ARCHIVED")));
+
+      assertThat(result.filters().get(0).operator()).isEqualTo(Operators.NOT_IN);
+      assertThat(result.filters().get(0).value()).isEqualTo(List.of("DELETED", "ARCHIVED"));
+    }
+
+    @Test
+    void shouldParseBetweenOperator() {
+      var result = parser.parse(Map.of("filter", List.of("price:between:10|100")));
+
+      assertThat(result.filters().get(0).operator()).isEqualTo(Operators.BETWEEN);
+      assertThat(result.filters().get(0).value()).isEqualTo(List.of("10", "100"));
+    }
+
+    @Test
+    void shouldParseSingleValueForInOperator() {
+      var result = parser.parse(Map.of("filter", List.of("status:in:ACTIVE")));
+      assertThat(result.filters().get(0).value()).isEqualTo(List.of("ACTIVE"));
+    }
+  }
+
+  @Nested
+  class OrGroupTests {
+
+    @Test
+    void shouldParseSingleOrGroup() {
+      var result =
+          parser.parse(Map.of("orFilter", List.of("name:contains:John;description:contains:John")));
+
+      assertThat(result.orGroups()).hasSize(1);
+      var group = result.orGroups().get(0);
+      assertThat(group.filters()).hasSize(2);
+      assertThat(group.filters().get(0).field()).isEqualTo("name");
+      assertThat(group.filters().get(1).field()).isEqualTo("description");
+    }
+
+    @Test
+    void shouldParseMultipleOrGroups() {
+      var result =
+          parser.parse(
+              Map.of("orFilter", List.of("name:eq:A;name:eq:B", "status:eq:X;status:eq:Y")));
+
+      assertThat(result.orGroups()).hasSize(2);
+    }
+
+    @Test
+    void shouldCombineFilterAndOrGroupCounts() {
+      var config = HttpFilterParserConfiguration.builder().maxFilters(3).build();
+      var p = new HttpFilterParser(config);
+
+      assertThatThrownBy(
+              () ->
+                  p.parse(
+                      Map.of(
+                          "filter",
+                          List.of("a:eq:1", "b:eq:2"),
+                          "orFilter",
+                          List.of("c:eq:3;d:eq:4"))))
+          .isInstanceOf(HttpFilterSyntaxException.class)
+          .hasMessageContaining("too many filters");
+    }
+  }
+
+  @Nested
+  class SortTests {
+
+    @Test
+    void shouldParseSortWithAscDirection() {
+      var result = parser.parse(Map.of("sort", List.of("name,asc")));
+
+      assertThat(result.sort()).isEqualTo(Sort.by(Sort.Order.asc("name")));
+    }
+
+    @Test
+    void shouldParseSortWithDescDirection() {
+      var result = parser.parse(Map.of("sort", List.of("price,desc")));
+
+      assertThat(result.sort()).isEqualTo(Sort.by(Sort.Order.desc("price")));
+    }
+
+    @Test
+    void shouldDefaultToAscWhenDirectionOmitted() {
+      var result = parser.parse(Map.of("sort", List.of("name")));
+
+      assertThat(result.sort()).isEqualTo(Sort.by(Sort.Order.asc("name")));
+    }
+
+    @Test
+    void shouldParseMultipleSortFields() {
+      var result = parser.parse(Map.of("sort", List.of("name,asc", "price,desc")));
+
+      assertThat(result.sort())
+          .isEqualTo(Sort.by(Sort.Order.asc("name"), Sort.Order.desc("price")));
+    }
+
+    @Test
+    void shouldBeCaseInsensitiveForDirection() {
+      var result = parser.parse(Map.of("sort", List.of("name,ASC", "price,DESC")));
+
+      assertThat(result.sort())
+          .isEqualTo(Sort.by(Sort.Order.asc("name"), Sort.Order.desc("price")));
+    }
+
+    @Test
+    void shouldRejectInvalidSortDirection() {
+      assertThatThrownBy(() -> parser.parse(Map.of("sort", List.of("name,invalid"))))
+          .isInstanceOf(HttpFilterSyntaxException.class)
+          .hasMessageContaining("invalid sort direction");
+    }
+
+    @Test
+    void shouldRejectEmptySortExpression() {
+      assertThatThrownBy(() -> parser.parse(Map.of("sort", List.of(""))))
+          .isInstanceOf(HttpFilterSyntaxException.class)
+          .hasMessageContaining("sort expression must not be empty");
+    }
+
+    @Test
+    void shouldRejectEmptySortField() {
+      assertThatThrownBy(() -> parser.parse(Map.of("sort", List.of(",asc"))))
+          .isInstanceOf(HttpFilterSyntaxException.class)
+          .hasMessageContaining("sort field must not be empty");
+    }
+
+    @Test
+    void shouldRejectSortWithExtraCommas() {
+      assertThatThrownBy(() -> parser.parse(Map.of("sort", List.of("name,asc,extra"))))
+          .isInstanceOf(HttpFilterSyntaxException.class)
+          .hasMessageContaining("sort expression must have at most 2 parts");
+    }
+
+    @Test
+    void shouldRejectInvalidSortFieldName() {
+      assertThatThrownBy(() -> parser.parse(Map.of("sort", List.of("../hack,asc"))))
+          .isInstanceOf(HttpFilterSyntaxException.class)
+          .hasMessageContaining("invalid field name");
+    }
+
+    @Test
+    void shouldRejectTooManySortFields() {
+      var config = HttpFilterParserConfiguration.builder().maxSortFields(2).build();
+      var p = new HttpFilterParser(config);
+
+      assertThatThrownBy(() -> p.parse(Map.of("sort", List.of("a,asc", "b,asc", "c,asc"))))
+          .isInstanceOf(HttpFilterSyntaxException.class)
+          .hasMessageContaining("too many sort fields");
+    }
+
+    @Test
+    void shouldReturnUnsortedWhenNoSortParam() {
+      var result = parser.parse(Map.of());
+      assertThat(result.sort().isUnsorted()).isTrue();
+    }
+  }
+
+  @Nested
+  class OperatorValidationTests {
+
+    @Test
+    void shouldRejectUnknownOperatorWhenAllowedOperatorsConfigured() {
+      var config =
+          HttpFilterParserConfiguration.builder().allowedOperators(Set.of("eq", "neq")).build();
+      var p = new HttpFilterParser(config);
+
+      assertThatThrownBy(() -> p.parse(Map.of("filter", List.of("name:contains:John"))))
+          .isInstanceOf(HttpUnknownOperatorException.class)
+          .hasMessageContaining("contains");
+    }
+
+    @Test
+    void shouldAcceptOperatorInAllowedSet() {
+      var config = HttpFilterParserConfiguration.builder().allowedOperators(Set.of("eq")).build();
+      var p = new HttpFilterParser(config);
+
+      var result = p.parse(Map.of("filter", List.of("name:eq:John")));
+      assertThat(result.filters()).hasSize(1);
+    }
+
+    @Test
+    void shouldAcceptAnyOperatorWhenAllowedOperatorsIsNull() {
+      var result = parser.parse(Map.of("filter", List.of("name:customop:value")));
+      assertThat(result.filters().get(0).operator()).isEqualTo(FilterOperator.of("customop"));
+    }
+  }
+
+  @Nested
+  class MaxFiltersTests {
+
+    @Test
+    void shouldRejectTooManyFilters() {
+      var config = HttpFilterParserConfiguration.builder().maxFilters(2).build();
+      var p = new HttpFilterParser(config);
+
+      assertThatThrownBy(() -> p.parse(Map.of("filter", List.of("a:eq:1", "b:eq:2", "c:eq:3"))))
+          .isInstanceOf(HttpFilterSyntaxException.class)
+          .hasMessageContaining("too many filters");
+    }
+
+    @Test
+    void shouldAcceptExactlyMaxFilters() {
+      var config = HttpFilterParserConfiguration.builder().maxFilters(2).build();
+      var p = new HttpFilterParser(config);
+
+      var result = p.parse(Map.of("filter", List.of("a:eq:1", "b:eq:2")));
+      assertThat(result.filters()).hasSize(2);
+    }
+  }
+
+  @Nested
+  class ApplyToTests {
+
+    @Test
+    void shouldApplyFiltersToBuilder() {
+      QueryPlanBuilder<TestEntity> builder = SpecificationQueryBuilder.forEntity(TestEntity.class);
+
+      parser.applyTo(builder, Map.of("filter", List.of("name:eq:John")));
+
+      QueryPlan<TestEntity> plan = builder.build();
+      assertThat(plan.rootCondition().conditions()).hasSize(1);
+      var cond = (PredicateCondition) plan.rootCondition().conditions().get(0);
+      assertThat(cond.field()).isEqualTo("name");
+      assertThat(cond.operator()).isEqualTo(Operators.EQUALS);
+      assertThat(cond.value()).isEqualTo("John");
+    }
+
+    @Test
+    void shouldApplyOrGroupsToBuilder() {
+      QueryPlanBuilder<TestEntity> builder = SpecificationQueryBuilder.forEntity(TestEntity.class);
+
+      parser.applyTo(builder, Map.of("orFilter", List.of("name:eq:A;name:eq:B")));
+
+      QueryPlan<TestEntity> plan = builder.build();
+      assertThat(plan.rootCondition().conditions()).hasSize(1);
+      var orGroup =
+          (com.borjaglez.specrepository.core.GroupCondition)
+              plan.rootCondition().conditions().get(0);
+      assertThat(orGroup.logicalOperator()).isEqualTo(LogicalOperator.OR);
+      assertThat(orGroup.conditions()).hasSize(2);
+    }
+
+    @Test
+    void shouldApplySortToBuilder() {
+      QueryPlanBuilder<TestEntity> builder = SpecificationQueryBuilder.forEntity(TestEntity.class);
+
+      parser.applyTo(builder, Map.of("sort", List.of("name,desc")));
+
+      QueryPlan<TestEntity> plan = builder.build();
+      assertThat(plan.sort()).isEqualTo(Sort.by(Sort.Order.desc("name")));
+    }
+
+    @Test
+    void shouldNotApplyUnsorted() {
+      QueryPlanBuilder<TestEntity> builder = SpecificationQueryBuilder.forEntity(TestEntity.class);
+      builder.sort(Sort.by("existing"));
+
+      parser.applyTo(builder, Map.of());
+
+      QueryPlan<TestEntity> plan = builder.build();
+      assertThat(plan.sort()).isEqualTo(Sort.by("existing"));
+    }
+
+    @Test
+    void shouldRejectNullBuilder() {
+      assertThatThrownBy(() -> parser.applyTo(null, Map.of()))
+          .isInstanceOf(NullPointerException.class);
+    }
+  }
+
+  @Nested
+  class ToQueryPlanTests {
+
+    @Test
+    void shouldBuildQueryPlanFromParams() {
+      QueryPlan<TestEntity> plan =
+          parser.toQueryPlan(
+              TestEntity.class,
+              Map.of("filter", List.of("name:eq:John"), "sort", List.of("name,asc")));
+
+      assertThat(plan.entityType()).isEqualTo(TestEntity.class);
+      assertThat(plan.rootCondition().conditions()).hasSize(1);
+      assertThat(plan.sort()).isEqualTo(Sort.by(Sort.Order.asc("name")));
+    }
+
+    @Test
+    void shouldBuildQueryPlanWithAllowedFieldsPolicy() {
+      AllowedFieldsPolicy policy = AllowedFieldsPolicy.of(Set.of("name"), Set.of("name"));
+
+      QueryPlan<TestEntity> plan =
+          parser.toQueryPlan(TestEntity.class, Map.of("filter", List.of("name:eq:John")), policy);
+
+      assertThat(plan.allowedFieldsPolicy()).isSameAs(policy);
+    }
+
+    @Test
+    void shouldRejectNullEntityType() {
+      assertThatThrownBy(() -> parser.toQueryPlan(null, Map.of()))
+          .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void shouldRejectNullEntityTypeWithPolicy() {
+      assertThatThrownBy(() -> parser.toQueryPlan(null, Map.of(), AllowedFieldsPolicy.allowAll()))
+          .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void shouldRejectNullPolicy() {
+      assertThatThrownBy(() -> parser.toQueryPlan(TestEntity.class, Map.of(), null))
+          .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void shouldBuildEmptyQueryPlan() {
+      QueryPlan<TestEntity> plan = parser.toQueryPlan(TestEntity.class, Map.of());
+
+      assertThat(plan.entityType()).isEqualTo(TestEntity.class);
+      assertThat(plan.rootCondition().conditions()).isEmpty();
+      assertThat(plan.sort().isUnsorted()).isTrue();
+    }
+  }
+
+  @Nested
+  class CustomConfigTests {
+
+    @Test
+    void shouldUseCustomParameterNames() {
+      var config =
+          HttpFilterParserConfiguration.builder()
+              .filterParam("f")
+              .orFilterParam("of")
+              .sortParam("s")
+              .build();
+      var p = new HttpFilterParser(config);
+
+      var result =
+          p.parse(
+              Map.of(
+                  "f", List.of("name:eq:John"),
+                  "of", List.of("a:eq:1;b:eq:2"),
+                  "s", List.of("name,desc")));
+
+      assertThat(result.filters()).hasSize(1);
+      assertThat(result.orGroups()).hasSize(1);
+      assertThat(result.sort()).isEqualTo(Sort.by(Sort.Order.desc("name")));
+    }
+
+    @Test
+    void shouldUseCustomMultiValueSeparator() {
+      var config = HttpFilterParserConfiguration.builder().multiValueSeparator(",").build();
+      var p = new HttpFilterParser(config);
+
+      var result = p.parse(Map.of("filter", List.of("status:in:ACTIVE,PENDING")));
+
+      assertThat(result.filters().get(0).value()).isEqualTo(List.of("ACTIVE", "PENDING"));
+    }
+
+    @Test
+    void shouldUseCustomOrGroupSeparator() {
+      var config = HttpFilterParserConfiguration.builder().orGroupSeparator("&").build();
+      var p = new HttpFilterParser(config);
+
+      var result = p.parse(Map.of("orFilter", List.of("a:eq:1&b:eq:2")));
+
+      assertThat(result.orGroups().get(0).filters()).hasSize(2);
+    }
+  }
+
+  @Nested
+  class AllOperatorsTests {
+
+    @Test
+    void shouldParseAllStringOperators() {
+      var operators = List.of("contains", "notcontains", "startswith", "endswith");
+      for (String op : operators) {
+        var result = parser.parse(Map.of("filter", List.of("name:" + op + ":test")));
+        assertThat(result.filters().get(0).operator()).isEqualTo(FilterOperator.of(op));
+      }
+    }
+
+    @Test
+    void shouldParseAllComparisonOperators() {
+      var operators = List.of("gt", "gte", "lt", "lte");
+      for (String op : operators) {
+        var result = parser.parse(Map.of("filter", List.of("price:" + op + ":100")));
+        assertThat(result.filters().get(0).operator()).isEqualTo(FilterOperator.of(op));
+      }
+    }
+  }
+}

--- a/specification-repository-http/src/test/java/com/borjaglez/specrepository/http/HttpFilterSyntaxExceptionTest.java
+++ b/specification-repository-http/src/test/java/com/borjaglez/specrepository/http/HttpFilterSyntaxExceptionTest.java
@@ -1,0 +1,17 @@
+package com.borjaglez.specrepository.http;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class HttpFilterSyntaxExceptionTest {
+
+  @Test
+  void shouldExposeRawExpressionAndReason() {
+    var ex = new HttpFilterSyntaxException("bad:expr", "missing value");
+
+    assertThat(ex.rawExpression()).isEqualTo("bad:expr");
+    assertThat(ex.reason()).isEqualTo("missing value");
+    assertThat(ex.getMessage()).isEqualTo("Invalid filter expression 'bad:expr': missing value");
+  }
+}

--- a/specification-repository-http/src/test/java/com/borjaglez/specrepository/http/HttpUnknownOperatorExceptionTest.java
+++ b/specification-repository-http/src/test/java/com/borjaglez/specrepository/http/HttpUnknownOperatorExceptionTest.java
@@ -1,0 +1,16 @@
+package com.borjaglez.specrepository.http;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class HttpUnknownOperatorExceptionTest {
+
+  @Test
+  void shouldExposeOperator() {
+    var ex = new HttpUnknownOperatorException("badop");
+
+    assertThat(ex.operator()).isEqualTo("badop");
+    assertThat(ex.getMessage()).isEqualTo("Unknown filter operator 'badop'");
+  }
+}

--- a/specification-repository-http/src/test/java/com/borjaglez/specrepository/http/ParsedHttpQueryTest.java
+++ b/specification-repository-http/src/test/java/com/borjaglez/specrepository/http/ParsedHttpQueryTest.java
@@ -1,0 +1,88 @@
+package com.borjaglez.specrepository.http;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Sort;
+
+import com.borjaglez.specrepository.core.FilterOperator;
+import com.borjaglez.specrepository.http.ParsedHttpQuery.ParsedFilter;
+import com.borjaglez.specrepository.http.ParsedHttpQuery.ParsedOrGroup;
+
+class ParsedHttpQueryTest {
+
+  @Test
+  void shouldCreateImmutableQuery() {
+    var filter = new ParsedFilter("name", FilterOperator.of("eq"), "John");
+    var orGroup = new ParsedOrGroup(List.of(filter));
+    var query = new ParsedHttpQuery(List.of(filter), List.of(orGroup), Sort.unsorted());
+
+    assertThat(query.filters()).hasSize(1);
+    assertThat(query.orGroups()).hasSize(1);
+    assertThat(query.sort()).isEqualTo(Sort.unsorted());
+  }
+
+  @Test
+  void shouldRejectNullFilters() {
+    assertThatThrownBy(() -> new ParsedHttpQuery(null, List.of(), Sort.unsorted()))
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  void shouldRejectNullOrGroups() {
+    assertThatThrownBy(() -> new ParsedHttpQuery(List.of(), null, Sort.unsorted()))
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  void shouldRejectNullSort() {
+    assertThatThrownBy(() -> new ParsedHttpQuery(List.of(), List.of(), null))
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  void parsedFilterShouldRejectNullField() {
+    assertThatThrownBy(() -> new ParsedFilter(null, FilterOperator.of("eq"), "v"))
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  void parsedFilterShouldRejectNullOperator() {
+    assertThatThrownBy(() -> new ParsedFilter("f", null, "v"))
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  void parsedFilterShouldAllowNullValue() {
+    var filter = new ParsedFilter("f", FilterOperator.of("isnull"), null);
+    assertThat(filter.value()).isNull();
+  }
+
+  @Test
+  void parsedOrGroupShouldRejectNullFilters() {
+    assertThatThrownBy(() -> new ParsedOrGroup(null)).isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  void shouldReturnDefensiveCopies() {
+    var filter = new ParsedFilter("name", FilterOperator.of("eq"), "John");
+    var query = new ParsedHttpQuery(List.of(filter), List.of(), Sort.unsorted());
+
+    assertThatThrownBy(() -> query.filters().add(filter))
+        .isInstanceOf(UnsupportedOperationException.class);
+    assertThatThrownBy(() -> query.orGroups().add(new ParsedOrGroup(List.of())))
+        .isInstanceOf(UnsupportedOperationException.class);
+  }
+
+  @Test
+  void parsedOrGroupShouldReturnDefensiveCopy() {
+    var filter = new ParsedFilter("name", FilterOperator.of("eq"), "John");
+    var group = new ParsedOrGroup(List.of(filter));
+
+    assertThatThrownBy(() -> group.filters().add(filter))
+        .isInstanceOf(UnsupportedOperationException.class);
+  }
+}

--- a/specification-repository-http/src/test/java/com/borjaglez/specrepository/http/spring/FilterableQueryTest.java
+++ b/specification-repository-http/src/test/java/com/borjaglez/specrepository/http/spring/FilterableQueryTest.java
@@ -1,0 +1,47 @@
+package com.borjaglez.specrepository.http.spring;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+
+import org.junit.jupiter.api.Test;
+
+import com.borjaglez.specrepository.core.QueryPlan;
+
+class FilterableQueryTest {
+
+  static class TestEntity {}
+
+  @SuppressWarnings("unused")
+  void sampleMethod(
+      @FilterableQuery(
+              value = TestEntity.class,
+              filterableFields = {"name", "status"},
+              sortableFields = {"name"})
+          QueryPlan<TestEntity> query) {}
+
+  @SuppressWarnings("unused")
+  void defaultsMethod(@FilterableQuery(TestEntity.class) QueryPlan<TestEntity> query) {}
+
+  @Test
+  void shouldExposeAnnotationValues() throws Exception {
+    Method method = getClass().getDeclaredMethod("sampleMethod", QueryPlan.class);
+    Annotation[][] annotations = method.getParameterAnnotations();
+    FilterableQuery fq = (FilterableQuery) annotations[0][0];
+
+    assertThat(fq.value()).isEqualTo(TestEntity.class);
+    assertThat(fq.filterableFields()).containsExactly("name", "status");
+    assertThat(fq.sortableFields()).containsExactly("name");
+  }
+
+  @Test
+  void shouldHaveEmptyDefaultsForFieldLists() throws Exception {
+    Method method = getClass().getDeclaredMethod("defaultsMethod", QueryPlan.class);
+    Annotation[][] annotations = method.getParameterAnnotations();
+    FilterableQuery fq = (FilterableQuery) annotations[0][0];
+
+    assertThat(fq.filterableFields()).isEmpty();
+    assertThat(fq.sortableFields()).isEmpty();
+  }
+}

--- a/specification-repository-http/src/test/java/com/borjaglez/specrepository/http/spring/HttpFilterAutoConfigurationTest.java
+++ b/specification-repository-http/src/test/java/com/borjaglez/specrepository/http/spring/HttpFilterAutoConfigurationTest.java
@@ -1,0 +1,69 @@
+package com.borjaglez.specrepository.http.spring;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import com.borjaglez.specrepository.http.HttpFilterParser;
+import com.borjaglez.specrepository.http.HttpFilterParserConfiguration;
+
+class HttpFilterAutoConfigurationTest {
+
+  private final WebApplicationContextRunner contextRunner =
+      new WebApplicationContextRunner()
+          .withConfiguration(AutoConfigurations.of(HttpFilterAutoConfiguration.class));
+
+  @Test
+  void shouldRegisterBeans() {
+    contextRunner.run(
+        context -> {
+          assertThat(context).hasSingleBean(HttpFilterParser.class);
+          assertThat(context).hasSingleBean(QueryPlanArgumentResolver.class);
+        });
+  }
+
+  @Test
+  void shouldRespectCustomParserBean() {
+    HttpFilterParser customParser =
+        new HttpFilterParser(HttpFilterParserConfiguration.builder().filterParam("custom").build());
+    contextRunner
+        .withBean(HttpFilterParser.class, () -> customParser)
+        .run(
+            context -> {
+              assertThat(context).hasSingleBean(HttpFilterParser.class);
+              assertThat(context.getBean(HttpFilterParser.class)).isSameAs(customParser);
+            });
+  }
+
+  @Test
+  void shouldRespectCustomResolverBean() {
+    QueryPlanArgumentResolver customResolver =
+        new QueryPlanArgumentResolver(new HttpFilterParser());
+    contextRunner
+        .withBean(QueryPlanArgumentResolver.class, () -> customResolver)
+        .run(
+            context -> {
+              assertThat(context).hasSingleBean(QueryPlanArgumentResolver.class);
+              assertThat(context.getBean(QueryPlanArgumentResolver.class)).isSameAs(customResolver);
+            });
+  }
+
+  @Test
+  void shouldRegisterWebMvcConfigurerThatAddsResolver() {
+    contextRunner.run(
+        context -> {
+          WebMvcConfigurer configurer = context.getBean(WebMvcConfigurer.class);
+          List<HandlerMethodArgumentResolver> resolvers = new ArrayList<>();
+          configurer.addArgumentResolvers(resolvers);
+          assertThat(resolvers).hasSize(1);
+          assertThat(resolvers.get(0)).isInstanceOf(QueryPlanArgumentResolver.class);
+        });
+  }
+}

--- a/specification-repository-http/src/test/java/com/borjaglez/specrepository/http/spring/QueryPlanArgumentResolverTest.java
+++ b/specification-repository-http/src/test/java/com/borjaglez/specrepository/http/spring/QueryPlanArgumentResolverTest.java
@@ -1,0 +1,147 @@
+package com.borjaglez.specrepository.http.spring;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Method;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.core.MethodParameter;
+import org.springframework.web.context.request.NativeWebRequest;
+
+import com.borjaglez.specrepository.core.AllowedFieldsPolicy;
+import com.borjaglez.specrepository.core.Operators;
+import com.borjaglez.specrepository.core.PredicateCondition;
+import com.borjaglez.specrepository.core.QueryPlan;
+import com.borjaglez.specrepository.http.HttpFilterParser;
+
+class QueryPlanArgumentResolverTest {
+
+  private final HttpFilterParser parser = new HttpFilterParser();
+  private final QueryPlanArgumentResolver resolver = new QueryPlanArgumentResolver(parser);
+
+  static class TestEntity {}
+
+  @SuppressWarnings("unused")
+  void annotatedMethod(
+      @FilterableQuery(
+              value = TestEntity.class,
+              filterableFields = {"name"},
+              sortableFields = {"name"})
+          QueryPlan<TestEntity> query) {}
+
+  @SuppressWarnings("unused")
+  void defaultAnnotatedMethod(@FilterableQuery(TestEntity.class) QueryPlan<TestEntity> query) {}
+
+  @SuppressWarnings("unused")
+  void sortableOnlyMethod(
+      @FilterableQuery(
+              value = TestEntity.class,
+              sortableFields = {"name"})
+          QueryPlan<TestEntity> query) {}
+
+  @SuppressWarnings("unused")
+  void nonAnnotatedMethod(QueryPlan<TestEntity> query) {}
+
+  @SuppressWarnings("unused")
+  void wrongTypeMethod(@FilterableQuery(TestEntity.class) String notAQueryPlan) {}
+
+  @Test
+  void shouldSupportAnnotatedQueryPlanParameter() throws Exception {
+    MethodParameter param = getParam("annotatedMethod", QueryPlan.class);
+    assertThat(resolver.supportsParameter(param)).isTrue();
+  }
+
+  @Test
+  void shouldNotSupportNonAnnotatedParameter() throws Exception {
+    MethodParameter param = getParam("nonAnnotatedMethod", QueryPlan.class);
+    assertThat(resolver.supportsParameter(param)).isFalse();
+  }
+
+  @Test
+  void shouldNotSupportWrongType() throws Exception {
+    MethodParameter param = getParam("wrongTypeMethod", String.class);
+    assertThat(resolver.supportsParameter(param)).isFalse();
+  }
+
+  @Test
+  void shouldResolveQueryPlanFromRequestParams() throws Exception {
+    MethodParameter param = getParam("annotatedMethod", QueryPlan.class);
+    NativeWebRequest webRequest = mock(NativeWebRequest.class);
+    when(webRequest.getParameterMap())
+        .thenReturn(
+            Map.of("filter", new String[] {"name:eq:John"}, "sort", new String[] {"name,asc"}));
+
+    @SuppressWarnings("unchecked")
+    QueryPlan<TestEntity> plan =
+        (QueryPlan<TestEntity>) resolver.resolveArgument(param, null, webRequest, null);
+
+    assertThat(plan).isNotNull();
+    assertThat(plan.entityType()).isEqualTo(TestEntity.class);
+    assertThat(plan.rootCondition().conditions()).hasSize(1);
+    var cond = (PredicateCondition) plan.rootCondition().conditions().get(0);
+    assertThat(cond.field()).isEqualTo("name");
+    assertThat(cond.operator()).isEqualTo(Operators.EQUALS);
+  }
+
+  @Test
+  void shouldApplyFieldRestrictions() throws Exception {
+    MethodParameter param = getParam("annotatedMethod", QueryPlan.class);
+    NativeWebRequest webRequest = mock(NativeWebRequest.class);
+    when(webRequest.getParameterMap()).thenReturn(Map.of("filter", new String[] {"name:eq:John"}));
+
+    @SuppressWarnings("unchecked")
+    QueryPlan<TestEntity> plan =
+        (QueryPlan<TestEntity>) resolver.resolveArgument(param, null, webRequest, null);
+
+    assertThat(plan.allowedFieldsPolicy()).isNotSameAs(AllowedFieldsPolicy.allowAll());
+  }
+
+  @Test
+  void shouldUseAllowAllWhenNoFieldsSpecified() throws Exception {
+    MethodParameter param = getParam("defaultAnnotatedMethod", QueryPlan.class);
+    NativeWebRequest webRequest = mock(NativeWebRequest.class);
+    when(webRequest.getParameterMap()).thenReturn(Map.of());
+
+    @SuppressWarnings("unchecked")
+    QueryPlan<TestEntity> plan =
+        (QueryPlan<TestEntity>) resolver.resolveArgument(param, null, webRequest, null);
+
+    assertThat(plan.allowedFieldsPolicy()).isSameAs(AllowedFieldsPolicy.allowAll());
+  }
+
+  @Test
+  void shouldApplyPolicyWhenOnlySortableFieldsSpecified() throws Exception {
+    MethodParameter param = getParam("sortableOnlyMethod", QueryPlan.class);
+    NativeWebRequest webRequest = mock(NativeWebRequest.class);
+    when(webRequest.getParameterMap()).thenReturn(Map.of());
+
+    @SuppressWarnings("unchecked")
+    QueryPlan<TestEntity> plan =
+        (QueryPlan<TestEntity>) resolver.resolveArgument(param, null, webRequest, null);
+
+    assertThat(plan.allowedFieldsPolicy()).isNotSameAs(AllowedFieldsPolicy.allowAll());
+  }
+
+  @Test
+  void shouldResolveEmptyParams() throws Exception {
+    MethodParameter param = getParam("defaultAnnotatedMethod", QueryPlan.class);
+    NativeWebRequest webRequest = mock(NativeWebRequest.class);
+    when(webRequest.getParameterMap()).thenReturn(Map.of());
+
+    @SuppressWarnings("unchecked")
+    QueryPlan<TestEntity> plan =
+        (QueryPlan<TestEntity>) resolver.resolveArgument(param, null, webRequest, null);
+
+    assertThat(plan.rootCondition().conditions()).isEmpty();
+  }
+
+  private MethodParameter getParam(String methodName, Class<?> paramType) throws Exception {
+    Method method = getClass().getDeclaredMethod(methodName, paramType);
+    MethodParameter param = new MethodParameter(method, 0);
+    param.initParameterNameDiscovery(null);
+    return param;
+  }
+}


### PR DESCRIPTION
## Summary
- New optional `specification-repository-http` module that translates HTTP query parameters (`filter=field:op:value`, `orFilter`, `sort`) into `QueryPlan`/DSL operations.
- Pure Java `HttpFilterParser` (no Spring dependency) plus Spring MVC `@FilterableQuery` argument resolver with `HttpFilterAutoConfiguration` for Boot 3 and Boot 4.
- Field name validation, per-endpoint `AllowedFieldsPolicy` whitelisting, configurable limits and separators, and dedicated syntax/unknown-operator exceptions.
- Demo endpoint `GET /api/products/filter` in `boot3-demo` and README section documenting the feature.

Closes #22

## Test plan
- [x] `./gradlew :specification-repository-http:test`
- [x] `./gradlew :specification-repository-http:check` (100% coverage gate)
- [x] `./gradlew spotlessCheckAll`
- [x] `./gradlew quality`
- [x] `./gradlew :examples:boot3-demo:bootRun` and verify `/api/products/filter?filter=name:contains:Laptop&sort=price,desc`