### PR TITLE
feat: add EXISTS and subquery support to DSL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- DSL support for `EXISTS` / `NOT EXISTS` and `IN (subquery)` / `NOT IN (subquery)` with association-based or entity-based correlation (#23)
+
 ## [0.1.0-rc.1] - 2026-04-06
 
 ### Miscellaneous

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Extensible Spring Data JPA query library with a fluent DSL and native-friendly a
 ## Features
 
 - Fluent query DSL for chained `where`, `and`, `or`, `join`, and `fetch` operations
+- Correlated subqueries: `exists` / `notExists` (association or entity-based) and `inSubquery` / `notInSubquery`
 - Aggregate projections with `sum`, `avg`, `min`, `max`, and `count(field)`
 - Pure builder model -- the builder only creates an immutable query plan
 - `SpecificationRepository` as a repository base abstraction for execution
@@ -375,6 +376,58 @@ long total = productRepository.query()
     .where("status", Operators.EQUALS, "ACTIVE")
     .count();
 ```
+
+### EXISTS and Subqueries
+
+For collection associations and cross-entity filters, the DSL supports correlated
+subqueries that translate to real SQL `EXISTS` / `IN (SELECT ...)` without
+polluting the outer query with joins or row duplication.
+
+**Association-based `EXISTS`** walks an existing outer association:
+
+```java
+List<Customer> results = customerRepository.query()
+    .where("status", Operators.EQUALS, "ACTIVE")
+    .<Order>exists("orders", sub -> sub.where("total", Operators.GREATER_THAN, 100))
+    .findAll();
+```
+
+**`NOT EXISTS`** is the canonical way to express "none of the related rows
+match" -- something a plain `where("orders.status", NOT_EQUALS, ...)` cannot do
+correctly:
+
+```java
+List<Customer> noCancellations = customerRepository.query()
+    .<Order>notExists("orders", sub -> sub.where("status", Operators.EQUALS, "CANCELLED"))
+    .findAll();
+```
+
+**Entity-based correlation** lets you query any entity class, not just a
+navigable association, and correlate explicitly via one or more field pairs:
+
+```java
+List<Customer> vipBuyers = customerRepository.query()
+    .exists(Order.class, sub -> sub
+        .correlate("id", "customer.id")
+        .where("status", Operators.EQUALS, "PAID")
+        .where("vip", Operators.EQUALS, true))
+    .findAll();
+```
+
+**`IN (subquery)` and `NOT IN (subquery)`** take the outer field to match, the
+sub-entity class, the projected field from the subquery, and the body:
+
+```java
+List<Customer> inSubquery = customerRepository.query()
+    .inSubquery("id", Order.class, "customer.id",
+        sub -> sub.where("vip", Operators.EQUALS, true))
+    .findAll();
+```
+
+Subquery calls compose with `and` / `or` groups like any other predicate and
+respect `AllowedFieldsPolicy` on their outer fields. See
+[docs/subqueries.md](docs/subqueries.md) for the full API, correlation
+semantics, and current limitations.
 
 ### IN Operator with Distinct
 

--- a/docs/subqueries.md
+++ b/docs/subqueries.md
@@ -114,10 +114,11 @@ inner repository.
 - `inSubquery` only supports entity-based correlation and a single projection
   column; multi-column tuples are not supported.
 - `inSubquery` / `notInSubquery` do not have an association-based overload.
-- Nesting subqueries inside subqueries is supported by the translator, but
-  the DSL currently only exposes `where` / `and` / `or` / `correlate` inside
-  a subquery body — not further `exists` / `inSubquery`. Use entity-based
-  correlation via a flat structure instead.
+- Nested subqueries are supported by the translator and are expressible in
+  the DSL via grouped conditions passed to subquery-body `and(...)` /
+  `or(...)`, whose inner builder exposes `exists` / `inSubquery`. Prefer a
+  flatter structure when it reads more clearly, but nested forms are
+  available.
 - Aggregate / scalar subqueries (e.g. `(SELECT MAX(...) FROM ...)`) are not
   exposed through the DSL.
 

--- a/docs/subqueries.md
+++ b/docs/subqueries.md
@@ -1,0 +1,128 @@
+# EXISTS and subqueries
+
+The DSL supports correlated subqueries for two families of filters that cannot be
+expressed as navigable join-based predicates:
+
+- `EXISTS` / `NOT EXISTS`
+- `IN (subquery)` / `NOT IN (subquery)`
+
+These translate to real SQL subqueries via the JPA Criteria API, so the outer
+query is not polluted by extra joins or row duplication.
+
+## Why not just join?
+
+Filtering a collection association with a normal `where` works for trivial
+cases, but it:
+
+1. Duplicates outer rows when the association is `@OneToMany` / `@ManyToMany`,
+   forcing `distinct()` and breaking stable pagination.
+2. Cannot express *negation over a collection* ("customers with no cancelled
+   order"): `where("orders.status", NOT_EQUALS, "CANCELLED")` only hides rows
+   where the join matched, leaving the customer in the result via other rows.
+3. Cannot filter by entities that are not mapped as an association from the
+   outer root.
+
+Subqueries solve all three.
+
+## API
+
+All subquery methods live on `ConditionGroupBuilder<T>` (and therefore on
+`QueryPlanBuilder<T>` / `SpecificationExecutableQuery<T>`).
+
+### Association-based correlation
+
+Use when the subquery walks an association already mapped on the outer entity.
+Correlation is implicit:
+
+```java
+customers.query()
+    .where("status", Operators.EQUALS, "ACTIVE")
+    .<Order>exists("orders", sub -> sub.where("total", Operators.GREATER_THAN, 100))
+    .findAll();
+```
+
+`notExists` mirrors the same shape:
+
+```java
+customers.query()
+    .<Order>notExists("orders", sub -> sub.where("status", Operators.EQUALS, "CANCELLED"))
+    .findAll();
+```
+
+### Entity-based correlation
+
+Use when the subquery is over an arbitrary entity class. Correlation is
+explicit via one or more `correlate(outerField, innerField)` calls:
+
+```java
+customers.query()
+    .exists(Order.class, sub -> sub
+        .correlate("id", "customer.id")
+        .where("status", Operators.EQUALS, "PAID"))
+    .findAll();
+```
+
+Multiple `correlate` calls are ANDed together, which lets you correlate on
+composite keys.
+
+### `IN (subquery)` and `NOT IN (subquery)`
+
+```java
+customers.query()
+    .inSubquery("id", Order.class, "customer.id",
+        sub -> sub.where("vip", Operators.EQUALS, true))
+    .findAll();
+```
+
+`notInSubquery` is the negation. `outerField` is the outer column to check
+membership of, and `subSelectField` is the single column projected from the
+subquery entity.
+
+## Composing subqueries with groups
+
+A subquery call participates in the containing group like any other condition,
+so it combines naturally with `and` / `or`:
+
+```java
+customers.query()
+    .or(group -> group
+        .where("status", Operators.EQUALS, "INACTIVE")
+        .<Order>exists("orders", sub -> sub.where("vip", Operators.EQUALS, true)))
+    .findAll();
+```
+
+Inside the subquery body you can use the same `where` / `and` / `or`
+primitives as the outer builder.
+
+## Validation and `AllowedFieldsPolicy`
+
+When an `AllowedFieldsPolicy` is configured, the outer fields referenced by a
+subquery are validated:
+
+- `inSubquery` / `notInSubquery`: the `outerField` must be in the allowed set.
+- Entity-based `exists` / `notExists`: the `outerField` of every
+  `correlate(...)` pair must be in the allowed set.
+
+Fields referenced *inside* the subquery body (on the sub-entity) are **not**
+validated against the outer policy, since they belong to a different entity.
+If you need sub-entity validation, enforce it with a separate policy on the
+inner repository.
+
+## Limitations
+
+- No `ALL` / `ANY` quantifiers.
+- `inSubquery` only supports entity-based correlation and a single projection
+  column; multi-column tuples are not supported.
+- `inSubquery` / `notInSubquery` do not have an association-based overload.
+- Nesting subqueries inside subqueries is supported by the translator, but
+  the DSL currently only exposes `where` / `and` / `or` / `correlate` inside
+  a subquery body — not further `exists` / `inSubquery`. Use entity-based
+  correlation via a flat structure instead.
+- Aggregate / scalar subqueries (e.g. `(SELECT MAX(...) FROM ...)`) are not
+  exposed through the DSL.
+
+## GraalVM native image
+
+Subquery translation does not use reflection; path resolution is done via
+the JPA metamodel, which is native-image friendly. No additional hints are
+required beyond what the library already registers.

--- a/specification-repository-core/src/main/java/com/borjaglez/specrepository/core/ConditionGroupBuilder.java
+++ b/specification-repository-core/src/main/java/com/borjaglez/specrepository/core/ConditionGroupBuilder.java
@@ -36,6 +36,51 @@ public final class ConditionGroupBuilder<T> {
     return group(LogicalOperator.OR, nested);
   }
 
+  public <S> ConditionGroupBuilder<T> exists(
+      String associationPath, Consumer<SubqueryBuilder<S>> body) {
+    conditions.add(SubqueryBuilder.buildAssociation(SubqueryKind.EXISTS, associationPath, body));
+    return this;
+  }
+
+  public <S> ConditionGroupBuilder<T> notExists(
+      String associationPath, Consumer<SubqueryBuilder<S>> body) {
+    conditions.add(
+        SubqueryBuilder.buildAssociation(SubqueryKind.NOT_EXISTS, associationPath, body));
+    return this;
+  }
+
+  public <S> ConditionGroupBuilder<T> exists(
+      Class<S> subEntity, Consumer<SubqueryBuilder<S>> body) {
+    conditions.add(SubqueryBuilder.buildEntity(SubqueryKind.EXISTS, subEntity, body));
+    return this;
+  }
+
+  public <S> ConditionGroupBuilder<T> notExists(
+      Class<S> subEntity, Consumer<SubqueryBuilder<S>> body) {
+    conditions.add(SubqueryBuilder.buildEntity(SubqueryKind.NOT_EXISTS, subEntity, body));
+    return this;
+  }
+
+  public <S> ConditionGroupBuilder<T> inSubquery(
+      String outerField,
+      Class<S> subEntity,
+      String subSelectField,
+      Consumer<SubqueryBuilder<S>> body) {
+    conditions.add(
+        SubqueryBuilder.buildIn(SubqueryKind.IN, outerField, subEntity, subSelectField, body));
+    return this;
+  }
+
+  public <S> ConditionGroupBuilder<T> notInSubquery(
+      String outerField,
+      Class<S> subEntity,
+      String subSelectField,
+      Consumer<SubqueryBuilder<S>> body) {
+    conditions.add(
+        SubqueryBuilder.buildIn(SubqueryKind.NOT_IN, outerField, subEntity, subSelectField, body));
+    return this;
+  }
+
   public GroupCondition build() {
     return new GroupCondition(logicalOperator, List.copyOf(conditions));
   }

--- a/specification-repository-core/src/main/java/com/borjaglez/specrepository/core/CorrelationMode.java
+++ b/specification-repository-core/src/main/java/com/borjaglez/specrepository/core/CorrelationMode.java
@@ -1,0 +1,6 @@
+package com.borjaglez.specrepository.core;
+
+public enum CorrelationMode {
+  ASSOCIATION,
+  ENTITY
+}

--- a/specification-repository-core/src/main/java/com/borjaglez/specrepository/core/CorrelationPair.java
+++ b/specification-repository-core/src/main/java/com/borjaglez/specrepository/core/CorrelationPair.java
@@ -1,0 +1,10 @@
+package com.borjaglez.specrepository.core;
+
+import java.util.Objects;
+
+public record CorrelationPair(String outerField, String innerField) {
+  public CorrelationPair {
+    Objects.requireNonNull(outerField, "outerField must not be null");
+    Objects.requireNonNull(innerField, "innerField must not be null");
+  }
+}

--- a/specification-repository-core/src/main/java/com/borjaglez/specrepository/core/QueryCondition.java
+++ b/specification-repository-core/src/main/java/com/borjaglez/specrepository/core/QueryCondition.java
@@ -1,3 +1,4 @@
 package com.borjaglez.specrepository.core;
 
-public sealed interface QueryCondition permits GroupCondition, PredicateCondition {}
+public sealed interface QueryCondition
+    permits GroupCondition, PredicateCondition, SubqueryCondition {}

--- a/specification-repository-core/src/main/java/com/borjaglez/specrepository/core/QueryPlanBuilder.java
+++ b/specification-repository-core/src/main/java/com/borjaglez/specrepository/core/QueryPlanBuilder.java
@@ -51,6 +51,45 @@ public class QueryPlanBuilder<T> {
     return this;
   }
 
+  public <S> QueryPlanBuilder<T> exists(String associationPath, Consumer<SubqueryBuilder<S>> body) {
+    rootGroup.exists(associationPath, body);
+    return this;
+  }
+
+  public <S> QueryPlanBuilder<T> notExists(
+      String associationPath, Consumer<SubqueryBuilder<S>> body) {
+    rootGroup.notExists(associationPath, body);
+    return this;
+  }
+
+  public <S> QueryPlanBuilder<T> exists(Class<S> subEntity, Consumer<SubqueryBuilder<S>> body) {
+    rootGroup.exists(subEntity, body);
+    return this;
+  }
+
+  public <S> QueryPlanBuilder<T> notExists(Class<S> subEntity, Consumer<SubqueryBuilder<S>> body) {
+    rootGroup.notExists(subEntity, body);
+    return this;
+  }
+
+  public <S> QueryPlanBuilder<T> inSubquery(
+      String outerField,
+      Class<S> subEntity,
+      String subSelectField,
+      Consumer<SubqueryBuilder<S>> body) {
+    rootGroup.inSubquery(outerField, subEntity, subSelectField, body);
+    return this;
+  }
+
+  public <S> QueryPlanBuilder<T> notInSubquery(
+      String outerField,
+      Class<S> subEntity,
+      String subSelectField,
+      Consumer<SubqueryBuilder<S>> body) {
+    rootGroup.notInSubquery(outerField, subEntity, subSelectField, body);
+    return this;
+  }
+
   public QueryPlanBuilder<T> leftJoin(String... paths) {
     return join(JoinMode.LEFT, paths);
   }

--- a/specification-repository-core/src/main/java/com/borjaglez/specrepository/core/SubqueryBuilder.java
+++ b/specification-repository-core/src/main/java/com/borjaglez/specrepository/core/SubqueryBuilder.java
@@ -53,6 +53,13 @@ public final class SubqueryBuilder<S> {
     Objects.requireNonNull(body, "body must not be null");
     SubqueryBuilder<S> builder = new SubqueryBuilder<>();
     body.accept(builder);
+    if (!builder.correlations.isEmpty()) {
+      throw new IllegalArgumentException(
+          "correlate(...) is not supported for association-based subqueries; correlation is"
+              + " implicit through the association path '"
+              + associationPath
+              + "'");
+    }
     return new SubqueryCondition(
         kind,
         CorrelationMode.ASSOCIATION,

--- a/specification-repository-core/src/main/java/com/borjaglez/specrepository/core/SubqueryBuilder.java
+++ b/specification-repository-core/src/main/java/com/borjaglez/specrepository/core/SubqueryBuilder.java
@@ -1,0 +1,106 @@
+package com.borjaglez.specrepository.core;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Consumer;
+
+public final class SubqueryBuilder<S> {
+  private final ConditionGroupBuilder<S> root = new ConditionGroupBuilder<>(LogicalOperator.AND);
+  private final List<CorrelationPair> correlations = new ArrayList<>();
+
+  public SubqueryBuilder<S> where(String field, FilterOperator operator, Object value) {
+    root.where(field, operator, value);
+    return this;
+  }
+
+  public SubqueryBuilder<S> where(
+      String field,
+      FilterOperator operator,
+      Object value,
+      boolean ignoreCase,
+      boolean includeNulls) {
+    root.where(field, operator, value, ignoreCase, includeNulls);
+    return this;
+  }
+
+  public SubqueryBuilder<S> and(Consumer<ConditionGroupBuilder<S>> nested) {
+    root.and(nested);
+    return this;
+  }
+
+  public SubqueryBuilder<S> or(Consumer<ConditionGroupBuilder<S>> nested) {
+    root.or(nested);
+    return this;
+  }
+
+  public SubqueryBuilder<S> correlate(String outerField, String innerField) {
+    correlations.add(new CorrelationPair(outerField, innerField));
+    return this;
+  }
+
+  GroupCondition buildCondition() {
+    return root.build();
+  }
+
+  List<CorrelationPair> correlations() {
+    return List.copyOf(correlations);
+  }
+
+  static <S> SubqueryCondition buildAssociation(
+      SubqueryKind kind, String associationPath, Consumer<SubqueryBuilder<S>> body) {
+    Objects.requireNonNull(associationPath, "associationPath must not be null");
+    Objects.requireNonNull(body, "body must not be null");
+    SubqueryBuilder<S> builder = new SubqueryBuilder<>();
+    body.accept(builder);
+    return new SubqueryCondition(
+        kind,
+        CorrelationMode.ASSOCIATION,
+        associationPath,
+        null,
+        List.of(),
+        null,
+        null,
+        builder.buildCondition());
+  }
+
+  static <S> SubqueryCondition buildEntity(
+      SubqueryKind kind, Class<S> subEntity, Consumer<SubqueryBuilder<S>> body) {
+    Objects.requireNonNull(subEntity, "subEntity must not be null");
+    Objects.requireNonNull(body, "body must not be null");
+    SubqueryBuilder<S> builder = new SubqueryBuilder<>();
+    body.accept(builder);
+    return new SubqueryCondition(
+        kind,
+        CorrelationMode.ENTITY,
+        null,
+        subEntity,
+        builder.correlations(),
+        null,
+        null,
+        builder.buildCondition());
+  }
+
+  static <S> SubqueryCondition buildIn(
+      SubqueryKind kind,
+      String outerField,
+      Class<S> subEntity,
+      String subSelectField,
+      Consumer<SubqueryBuilder<S>> body) {
+    Objects.requireNonNull(outerField, "outerField must not be null");
+    Objects.requireNonNull(subEntity, "subEntity must not be null");
+    Objects.requireNonNull(subSelectField, "subSelectField must not be null");
+    Objects.requireNonNull(body, "body must not be null");
+    SubqueryBuilder<S> builder = new SubqueryBuilder<>();
+    body.accept(builder);
+    return new SubqueryCondition(
+        kind,
+        CorrelationMode.ENTITY,
+        null,
+        subEntity,
+        builder.correlations(),
+        outerField,
+        subSelectField,
+        builder.buildCondition());
+  }
+}

--- a/specification-repository-core/src/main/java/com/borjaglez/specrepository/core/SubqueryCondition.java
+++ b/specification-repository-core/src/main/java/com/borjaglez/specrepository/core/SubqueryCondition.java
@@ -1,0 +1,32 @@
+package com.borjaglez.specrepository.core;
+
+import java.util.List;
+import java.util.Objects;
+
+public record SubqueryCondition(
+    SubqueryKind kind,
+    CorrelationMode correlationMode,
+    String associationPath,
+    Class<?> subEntity,
+    List<CorrelationPair> correlations,
+    String outerField,
+    String subSelectField,
+    GroupCondition subCondition)
+    implements QueryCondition {
+
+  public SubqueryCondition {
+    Objects.requireNonNull(kind, "kind must not be null");
+    Objects.requireNonNull(correlationMode, "correlationMode must not be null");
+    Objects.requireNonNull(subCondition, "subCondition must not be null");
+    correlations = List.copyOf(correlations == null ? List.of() : correlations);
+    if (correlationMode == CorrelationMode.ASSOCIATION) {
+      Objects.requireNonNull(associationPath, "associationPath must not be null for ASSOCIATION");
+    } else {
+      Objects.requireNonNull(subEntity, "subEntity must not be null for ENTITY");
+    }
+    if (kind == SubqueryKind.IN || kind == SubqueryKind.NOT_IN) {
+      Objects.requireNonNull(outerField, "outerField must not be null for IN/NOT_IN");
+      Objects.requireNonNull(subSelectField, "subSelectField must not be null for IN/NOT_IN");
+    }
+  }
+}

--- a/specification-repository-core/src/main/java/com/borjaglez/specrepository/core/SubqueryKind.java
+++ b/specification-repository-core/src/main/java/com/borjaglez/specrepository/core/SubqueryKind.java
@@ -1,0 +1,8 @@
+package com.borjaglez.specrepository.core;
+
+public enum SubqueryKind {
+  EXISTS,
+  NOT_EXISTS,
+  IN,
+  NOT_IN
+}

--- a/specification-repository-core/src/test/java/com/borjaglez/specrepository/core/ConditionGroupBuilderTest.java
+++ b/specification-repository-core/src/test/java/com/borjaglez/specrepository/core/ConditionGroupBuilderTest.java
@@ -1,6 +1,7 @@
 package com.borjaglez.specrepository.core;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 
 import org.junit.jupiter.api.Test;
@@ -91,6 +92,17 @@ class ConditionGroupBuilderTest {
     assertThat(sc.associationPath()).isEqualTo("orders");
     assertThat(sc.subEntity()).isNull();
     assertThat(sc.subCondition().conditions()).hasSize(1);
+  }
+
+  @Test
+  void existsAssociationShouldRejectCorrelateCalls() {
+    assertThatIllegalArgumentException()
+        .isThrownBy(
+            () ->
+                new ConditionGroupBuilder<Object>(LogicalOperator.AND)
+                    .<Object>exists("orders", sub -> sub.correlate("id", "customer.id")))
+        .withMessageContaining("correlate")
+        .withMessageContaining("orders");
   }
 
   @Test

--- a/specification-repository-core/src/test/java/com/borjaglez/specrepository/core/ConditionGroupBuilderTest.java
+++ b/specification-repository-core/src/test/java/com/borjaglez/specrepository/core/ConditionGroupBuilderTest.java
@@ -77,4 +77,109 @@ class ConditionGroupBuilderTest {
 
     assertThat(group.conditions()).isUnmodifiable();
   }
+
+  @Test
+  void existsAssociationShouldAddSubqueryCondition() {
+    GroupCondition group =
+        new ConditionGroupBuilder<Object>(LogicalOperator.AND)
+            .exists("orders", sub -> sub.where("total", Operators.GREATER_THAN, 10))
+            .build();
+
+    SubqueryCondition sc = (SubqueryCondition) group.conditions().get(0);
+    assertThat(sc.kind()).isEqualTo(SubqueryKind.EXISTS);
+    assertThat(sc.correlationMode()).isEqualTo(CorrelationMode.ASSOCIATION);
+    assertThat(sc.associationPath()).isEqualTo("orders");
+    assertThat(sc.subEntity()).isNull();
+    assertThat(sc.subCondition().conditions()).hasSize(1);
+  }
+
+  @Test
+  void notExistsAssociationShouldAddSubqueryCondition() {
+    GroupCondition group =
+        new ConditionGroupBuilder<Object>(LogicalOperator.AND)
+            .notExists("orders", sub -> sub.where("status", Operators.EQUALS, "CANCELLED"))
+            .build();
+
+    SubqueryCondition sc = (SubqueryCondition) group.conditions().get(0);
+    assertThat(sc.kind()).isEqualTo(SubqueryKind.NOT_EXISTS);
+    assertThat(sc.correlationMode()).isEqualTo(CorrelationMode.ASSOCIATION);
+  }
+
+  @Test
+  void existsEntityShouldAddSubqueryConditionWithCorrelations() {
+    GroupCondition group =
+        new ConditionGroupBuilder<Object>(LogicalOperator.AND)
+            .exists(
+                String.class,
+                sub -> sub.correlate("id", "customer.id").where("status", Operators.EQUALS, "PAID"))
+            .build();
+
+    SubqueryCondition sc = (SubqueryCondition) group.conditions().get(0);
+    assertThat(sc.kind()).isEqualTo(SubqueryKind.EXISTS);
+    assertThat(sc.correlationMode()).isEqualTo(CorrelationMode.ENTITY);
+    assertThat(sc.subEntity()).isEqualTo(String.class);
+    assertThat(sc.correlations())
+        .singleElement()
+        .satisfies(
+            pair -> {
+              assertThat(pair.outerField()).isEqualTo("id");
+              assertThat(pair.innerField()).isEqualTo("customer.id");
+            });
+  }
+
+  @Test
+  void notExistsEntityShouldAddSubqueryCondition() {
+    GroupCondition group =
+        new ConditionGroupBuilder<Object>(LogicalOperator.AND)
+            .notExists(String.class, sub -> sub.where("status", Operators.EQUALS, "X"))
+            .build();
+
+    SubqueryCondition sc = (SubqueryCondition) group.conditions().get(0);
+    assertThat(sc.kind()).isEqualTo(SubqueryKind.NOT_EXISTS);
+    assertThat(sc.correlationMode()).isEqualTo(CorrelationMode.ENTITY);
+    assertThat(sc.correlations()).isEmpty();
+  }
+
+  @Test
+  void inSubqueryShouldAddSubqueryCondition() {
+    GroupCondition group =
+        new ConditionGroupBuilder<Object>(LogicalOperator.AND)
+            .inSubquery(
+                "id", String.class, "customer.id", sub -> sub.where("vip", Operators.EQUALS, true))
+            .build();
+
+    SubqueryCondition sc = (SubqueryCondition) group.conditions().get(0);
+    assertThat(sc.kind()).isEqualTo(SubqueryKind.IN);
+    assertThat(sc.outerField()).isEqualTo("id");
+    assertThat(sc.subSelectField()).isEqualTo("customer.id");
+  }
+
+  @Test
+  void notInSubqueryShouldAddSubqueryCondition() {
+    GroupCondition group =
+        new ConditionGroupBuilder<Object>(LogicalOperator.AND)
+            .notInSubquery(
+                "id", String.class, "customer.id", sub -> sub.where("vip", Operators.EQUALS, true))
+            .build();
+
+    SubqueryCondition sc = (SubqueryCondition) group.conditions().get(0);
+    assertThat(sc.kind()).isEqualTo(SubqueryKind.NOT_IN);
+  }
+
+  @Test
+  void subqueryBuilderShouldSupportAllCompositionMethods() {
+    GroupCondition group =
+        new ConditionGroupBuilder<Object>(LogicalOperator.AND)
+            .exists(
+                "orders",
+                sub ->
+                    sub.where("total", Operators.GREATER_THAN, 10)
+                        .where("status", Operators.EQUALS, "PAID", true, true)
+                        .and(inner -> inner.where("vip", Operators.EQUALS, true))
+                        .or(inner -> inner.where("vip", Operators.EQUALS, false)))
+            .build();
+
+    SubqueryCondition sc = (SubqueryCondition) group.conditions().get(0);
+    assertThat(sc.subCondition().conditions()).hasSize(4);
+  }
 }

--- a/specification-repository-core/src/test/java/com/borjaglez/specrepository/core/CorrelationPairTest.java
+++ b/specification-repository-core/src/test/java/com/borjaglez/specrepository/core/CorrelationPairTest.java
@@ -1,0 +1,30 @@
+package com.borjaglez.specrepository.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+
+import org.junit.jupiter.api.Test;
+
+class CorrelationPairTest {
+
+  @Test
+  void shouldExposeFields() {
+    CorrelationPair pair = new CorrelationPair("outer", "inner");
+    assertThat(pair.outerField()).isEqualTo("outer");
+    assertThat(pair.innerField()).isEqualTo("inner");
+  }
+
+  @Test
+  void shouldRejectNullOuterField() {
+    assertThatNullPointerException()
+        .isThrownBy(() -> new CorrelationPair(null, "inner"))
+        .withMessage("outerField must not be null");
+  }
+
+  @Test
+  void shouldRejectNullInnerField() {
+    assertThatNullPointerException()
+        .isThrownBy(() -> new CorrelationPair("outer", null))
+        .withMessage("innerField must not be null");
+  }
+}

--- a/specification-repository-core/src/test/java/com/borjaglez/specrepository/core/QueryPlanBuilderTest.java
+++ b/specification-repository-core/src/test/java/com/borjaglez/specrepository/core/QueryPlanBuilderTest.java
@@ -257,6 +257,34 @@ class QueryPlanBuilderTest {
     assertThat(plan.entityType()).isEqualTo(Integer.class);
   }
 
+  @Test
+  void shouldExposeSubqueryDslOnQueryPlanBuilder() {
+    QueryPlan<String> plan =
+        SpecificationQueryBuilder.forEntity(String.class)
+            .<Integer>exists("orders", sub -> sub.where("total", Operators.GREATER_THAN, 10))
+            .<Integer>notExists("drafts", sub -> sub.where("x", Operators.EQUALS, 1))
+            .exists(Integer.class, sub -> sub.correlate("id", "ref"))
+            .notExists(Integer.class, sub -> sub.where("y", Operators.EQUALS, 2))
+            .inSubquery("id", Integer.class, "ref", sub -> sub.where("z", Operators.EQUALS, 3))
+            .notInSubquery("id", Integer.class, "ref", sub -> sub.where("w", Operators.EQUALS, 4))
+            .build();
+
+    assertThat(plan.rootCondition().conditions()).hasSize(6);
+    assertThat(plan.rootCondition().conditions())
+        .allMatch(condition -> condition instanceof SubqueryCondition);
+    assertThat(
+            plan.rootCondition().conditions().stream()
+                .map(c -> ((SubqueryCondition) c).kind())
+                .toList())
+        .containsExactly(
+            SubqueryKind.EXISTS,
+            SubqueryKind.NOT_EXISTS,
+            SubqueryKind.EXISTS,
+            SubqueryKind.NOT_EXISTS,
+            SubqueryKind.IN,
+            SubqueryKind.NOT_IN);
+  }
+
   private record NameEmailProjection(String name, String email) {}
 
   private record CountProjection(Long count) {}

--- a/specification-repository-core/src/test/java/com/borjaglez/specrepository/core/SubqueryConditionTest.java
+++ b/specification-repository-core/src/test/java/com/borjaglez/specrepository/core/SubqueryConditionTest.java
@@ -1,0 +1,139 @@
+package com.borjaglez.specrepository.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+class SubqueryConditionTest {
+
+  private static final GroupCondition EMPTY_BODY =
+      new GroupCondition(LogicalOperator.AND, List.of());
+
+  @Test
+  void associationConstructorRequiresAssociationPath() {
+    assertThatNullPointerException()
+        .isThrownBy(
+            () ->
+                new SubqueryCondition(
+                    SubqueryKind.EXISTS,
+                    CorrelationMode.ASSOCIATION,
+                    null,
+                    null,
+                    List.of(),
+                    null,
+                    null,
+                    EMPTY_BODY))
+        .withMessage("associationPath must not be null for ASSOCIATION");
+  }
+
+  @Test
+  void entityConstructorRequiresSubEntity() {
+    assertThatNullPointerException()
+        .isThrownBy(
+            () ->
+                new SubqueryCondition(
+                    SubqueryKind.EXISTS,
+                    CorrelationMode.ENTITY,
+                    null,
+                    null,
+                    List.of(),
+                    null,
+                    null,
+                    EMPTY_BODY))
+        .withMessage("subEntity must not be null for ENTITY");
+  }
+
+  @Test
+  void inKindRequiresOuterFieldAndSubSelectField() {
+    assertThatNullPointerException()
+        .isThrownBy(
+            () ->
+                new SubqueryCondition(
+                    SubqueryKind.IN,
+                    CorrelationMode.ENTITY,
+                    null,
+                    String.class,
+                    List.of(),
+                    null,
+                    "x",
+                    EMPTY_BODY))
+        .withMessage("outerField must not be null for IN/NOT_IN");
+    assertThatNullPointerException()
+        .isThrownBy(
+            () ->
+                new SubqueryCondition(
+                    SubqueryKind.IN,
+                    CorrelationMode.ENTITY,
+                    null,
+                    String.class,
+                    List.of(),
+                    "x",
+                    null,
+                    EMPTY_BODY))
+        .withMessage("subSelectField must not be null for IN/NOT_IN");
+  }
+
+  @Test
+  void constructorRequiresKindModeAndBody() {
+    assertThatNullPointerException()
+        .isThrownBy(
+            () ->
+                new SubqueryCondition(
+                    null,
+                    CorrelationMode.ENTITY,
+                    null,
+                    String.class,
+                    List.of(),
+                    null,
+                    null,
+                    EMPTY_BODY));
+    assertThatNullPointerException()
+        .isThrownBy(
+            () ->
+                new SubqueryCondition(
+                    SubqueryKind.EXISTS, null, "orders", null, List.of(), null, null, EMPTY_BODY));
+    assertThatNullPointerException()
+        .isThrownBy(
+            () ->
+                new SubqueryCondition(
+                    SubqueryKind.EXISTS,
+                    CorrelationMode.ASSOCIATION,
+                    "orders",
+                    null,
+                    List.of(),
+                    null,
+                    null,
+                    null));
+  }
+
+  @Test
+  void correlationsListShouldBeDefensivelyCopiedAndAllowNull() {
+    SubqueryCondition fromNull =
+        new SubqueryCondition(
+            SubqueryKind.EXISTS,
+            CorrelationMode.ENTITY,
+            null,
+            String.class,
+            null,
+            null,
+            null,
+            EMPTY_BODY);
+
+    assertThat(fromNull.correlations()).isEmpty();
+    assertThat(fromNull.correlations()).isUnmodifiable();
+  }
+
+  @Test
+  void enumsShouldExposeExpectedValues() {
+    assertThat(SubqueryKind.values())
+        .containsExactly(
+            SubqueryKind.EXISTS, SubqueryKind.NOT_EXISTS, SubqueryKind.IN, SubqueryKind.NOT_IN);
+    assertThat(CorrelationMode.values())
+        .containsExactly(CorrelationMode.ASSOCIATION, CorrelationMode.ENTITY);
+    assertThat(SubqueryKind.valueOf("EXISTS")).isEqualTo(SubqueryKind.EXISTS);
+    assertThat(CorrelationMode.valueOf("ENTITY")).isEqualTo(CorrelationMode.ENTITY);
+  }
+}

--- a/specification-repository-jpa/src/main/java/com/borjaglez/specrepository/jpa/SpecificationExecutableQuery.java
+++ b/specification-repository-jpa/src/main/java/com/borjaglez/specrepository/jpa/SpecificationExecutableQuery.java
@@ -13,6 +13,7 @@ import com.borjaglez.specrepository.core.ConditionGroupBuilder;
 import com.borjaglez.specrepository.core.FilterOperator;
 import com.borjaglez.specrepository.core.QueryPlan;
 import com.borjaglez.specrepository.core.QueryPlanBuilder;
+import com.borjaglez.specrepository.core.SubqueryBuilder;
 
 public class SpecificationExecutableQuery<T> extends QueryPlanBuilder<T> {
   private final SpecificationRepository<T, ?> repository;
@@ -50,6 +51,54 @@ public class SpecificationExecutableQuery<T> extends QueryPlanBuilder<T> {
   @Override
   public SpecificationExecutableQuery<T> or(Consumer<ConditionGroupBuilder<T>> nested) {
     super.or(nested);
+    return this;
+  }
+
+  @Override
+  public <S> SpecificationExecutableQuery<T> exists(
+      String associationPath, Consumer<SubqueryBuilder<S>> body) {
+    super.exists(associationPath, body);
+    return this;
+  }
+
+  @Override
+  public <S> SpecificationExecutableQuery<T> notExists(
+      String associationPath, Consumer<SubqueryBuilder<S>> body) {
+    super.notExists(associationPath, body);
+    return this;
+  }
+
+  @Override
+  public <S> SpecificationExecutableQuery<T> exists(
+      Class<S> subEntity, Consumer<SubqueryBuilder<S>> body) {
+    super.exists(subEntity, body);
+    return this;
+  }
+
+  @Override
+  public <S> SpecificationExecutableQuery<T> notExists(
+      Class<S> subEntity, Consumer<SubqueryBuilder<S>> body) {
+    super.notExists(subEntity, body);
+    return this;
+  }
+
+  @Override
+  public <S> SpecificationExecutableQuery<T> inSubquery(
+      String outerField,
+      Class<S> subEntity,
+      String subSelectField,
+      Consumer<SubqueryBuilder<S>> body) {
+    super.inSubquery(outerField, subEntity, subSelectField, body);
+    return this;
+  }
+
+  @Override
+  public <S> SpecificationExecutableQuery<T> notInSubquery(
+      String outerField,
+      Class<S> subEntity,
+      String subSelectField,
+      Consumer<SubqueryBuilder<S>> body) {
+    super.notInSubquery(outerField, subEntity, subSelectField, body);
     return this;
   }
 

--- a/specification-repository-jpa/src/main/java/com/borjaglez/specrepository/jpa/support/PathResolver.java
+++ b/specification-repository-jpa/src/main/java/com/borjaglez/specrepository/jpa/support/PathResolver.java
@@ -15,10 +15,19 @@ public class PathResolver {
 
   public Path<?> resolve(
       Root<?> root, AssociationRegistry registry, String path, JoinMode joinMode) {
+    return resolve(root, root.getModel(), registry, path, joinMode);
+  }
+
+  public Path<?> resolve(
+      From<?, ?> from,
+      ManagedType<?> fromType,
+      AssociationRegistry registry,
+      String path,
+      JoinMode joinMode) {
     String[] segments = path.split("\\.");
-    Path<?> currentPath = root;
-    From<?, ?> currentFrom = root;
-    ManagedType<?> currentType = root.getModel();
+    Path<?> currentPath = from;
+    From<?, ?> currentFrom = from;
+    ManagedType<?> currentType = fromType;
     StringBuilder associationPath = new StringBuilder();
 
     for (int index = 0; index < segments.length; index++) {
@@ -48,9 +57,18 @@ public class PathResolver {
   }
 
   public void join(Root<?> root, AssociationRegistry registry, String path, JoinMode joinMode) {
+    join(root, root.getModel(), registry, path, joinMode);
+  }
+
+  public void join(
+      From<?, ?> from,
+      ManagedType<?> fromType,
+      AssociationRegistry registry,
+      String path,
+      JoinMode joinMode) {
     String[] segments = path.split("\\.");
-    From<?, ?> currentFrom = root;
-    ManagedType<?> currentType = root.getModel();
+    From<?, ?> currentFrom = from;
+    ManagedType<?> currentType = fromType;
     StringBuilder associationPath = new StringBuilder();
 
     for (String segment : segments) {
@@ -82,6 +100,16 @@ public class PathResolver {
       currentFrom = (From<?, ?>) fetch;
       currentType = managedType(attribute);
     }
+  }
+
+  ManagedType<?> resolveAssociationTarget(ManagedType<?> fromType, String associationPath) {
+    String[] segments = associationPath.split("\\.");
+    ManagedType<?> currentType = fromType;
+    for (String segment : segments) {
+      Attribute<?, ?> attribute = currentType.getAttribute(segment);
+      currentType = managedType(attribute);
+    }
+    return currentType;
   }
 
   private boolean isAssociation(Attribute<?, ?> attribute) {

--- a/specification-repository-jpa/src/main/java/com/borjaglez/specrepository/jpa/support/QueryPlanSpecificationFactory.java
+++ b/specification-repository-jpa/src/main/java/com/borjaglez/specrepository/jpa/support/QueryPlanSpecificationFactory.java
@@ -6,13 +6,19 @@ import java.util.List;
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.CriteriaQuery;
 import jakarta.persistence.criteria.Expression;
+import jakarta.persistence.criteria.From;
+import jakarta.persistence.criteria.Join;
 import jakarta.persistence.criteria.Path;
 import jakarta.persistence.criteria.Predicate;
 import jakarta.persistence.criteria.Root;
+import jakarta.persistence.criteria.Subquery;
+import jakarta.persistence.metamodel.ManagedType;
 
 import org.springframework.data.jpa.domain.Specification;
 
 import com.borjaglez.specrepository.core.AllowedFieldsPolicy;
+import com.borjaglez.specrepository.core.CorrelationMode;
+import com.borjaglez.specrepository.core.CorrelationPair;
 import com.borjaglez.specrepository.core.FetchInstruction;
 import com.borjaglez.specrepository.core.GroupCondition;
 import com.borjaglez.specrepository.core.JoinInstruction;
@@ -21,6 +27,8 @@ import com.borjaglez.specrepository.core.LogicalOperator;
 import com.borjaglez.specrepository.core.PredicateCondition;
 import com.borjaglez.specrepository.core.QueryCondition;
 import com.borjaglez.specrepository.core.QueryPlan;
+import com.borjaglez.specrepository.core.SubqueryCondition;
+import com.borjaglez.specrepository.core.SubqueryKind;
 import com.borjaglez.specrepository.jpa.spi.OperatorContext;
 
 public class QueryPlanSpecificationFactory {
@@ -61,7 +69,9 @@ public class QueryPlanSpecificationFactory {
         query.distinct(true);
       }
 
-      Predicate predicate = toPredicate(plan.rootCondition(), root, criteriaBuilder, registry);
+      Predicate predicate =
+          toPredicate(
+              plan.rootCondition(), root, root.getModel(), query, criteriaBuilder, registry);
       if (predicate != null) {
         query.where(predicate);
       }
@@ -100,21 +110,28 @@ public class QueryPlanSpecificationFactory {
 
   private Predicate toPredicate(
       GroupCondition condition,
-      Root<?> root,
+      From<?, ?> from,
+      ManagedType<?> fromType,
+      CriteriaQuery<?> query,
       CriteriaBuilder criteriaBuilder,
       AssociationRegistry registry) {
     List<Predicate> predicates = new ArrayList<>();
     for (QueryCondition queryCondition : condition.conditions()) {
       if (queryCondition instanceof GroupCondition groupCondition) {
-        Predicate nested = toPredicate(groupCondition, root, criteriaBuilder, registry);
+        Predicate nested =
+            toPredicate(groupCondition, from, fromType, query, criteriaBuilder, registry);
         if (nested != null) {
           predicates.add(nested);
         }
         continue;
       }
+      if (queryCondition instanceof SubqueryCondition subqueryCondition) {
+        predicates.add(
+            translateSubquery(subqueryCondition, from, fromType, query, criteriaBuilder, registry));
+        continue;
+      }
       PredicateCondition predicateCondition = (PredicateCondition) queryCondition;
-      Path<?> path =
-          pathResolver.resolve(root, registry, predicateCondition.field(), JoinMode.LEFT);
+      Path<?> path = resolvePath(from, fromType, registry, predicateCondition.field());
       Object convertedValue =
           valueConversionService.convert(
               predicateCondition.value(), path.getJavaType(), predicateCondition.operator());
@@ -140,6 +157,93 @@ public class QueryPlanSpecificationFactory {
         : criteriaBuilder.and(predicateArray);
   }
 
+  private Predicate translateSubquery(
+      SubqueryCondition sc,
+      From<?, ?> outer,
+      ManagedType<?> outerType,
+      CriteriaQuery<?> query,
+      CriteriaBuilder cb,
+      AssociationRegistry outerRegistry) {
+    Subquery<Integer> sub = query.subquery(Integer.class);
+    AssociationRegistry subRegistry = new AssociationRegistry();
+    From<?, ?> subRoot;
+    ManagedType<?> subRootType;
+    Predicate correlationPredicate = null;
+
+    if (sc.correlationMode() == CorrelationMode.ASSOCIATION) {
+      From<?, ?> correlatedOuter = correlateOuter(sub, outer);
+      String[] segments = sc.associationPath().split("\\.");
+      From<?, ?> navigated = correlatedOuter;
+      ManagedType<?> currentType = outerType;
+      for (String segment : segments) {
+        Join<?, ?> join = navigated.join(segment, AssociationRegistry.toJoinType(JoinMode.INNER));
+        navigated = join;
+        currentType = pathResolver.resolveAssociationTarget(currentType, segment);
+      }
+      subRoot = navigated;
+      subRootType = currentType;
+    } else {
+      @SuppressWarnings("unchecked")
+      Class<Object> entityClass = (Class<Object>) sc.subEntity();
+      Root<Object> from = sub.from(entityClass);
+      subRoot = from;
+      subRootType = from.getModel();
+      List<Predicate> correlationPredicates = new ArrayList<>();
+      for (CorrelationPair pair : sc.correlations()) {
+        Path<?> outerPath = resolvePath(outer, outerType, outerRegistry, pair.outerField());
+        Path<?> innerPath = resolvePath(subRoot, subRootType, subRegistry, pair.innerField());
+        correlationPredicates.add(cb.equal(innerPath, outerPath));
+      }
+      if (!correlationPredicates.isEmpty()) {
+        correlationPredicate = cb.and(correlationPredicates.toArray(Predicate[]::new));
+      }
+    }
+
+    Predicate body = toPredicate(sc.subCondition(), subRoot, subRootType, query, cb, subRegistry);
+
+    List<Predicate> whereParts = new ArrayList<>();
+    if (correlationPredicate != null) {
+      whereParts.add(correlationPredicate);
+    }
+    if (body != null) {
+      whereParts.add(body);
+    }
+    if (!whereParts.isEmpty()) {
+      sub.where(whereParts.toArray(Predicate[]::new));
+    }
+
+    return switch (sc.kind()) {
+      case EXISTS -> {
+        sub.select(cb.literal(1));
+        yield cb.exists(sub);
+      }
+      case NOT_EXISTS -> {
+        sub.select(cb.literal(1));
+        yield cb.not(cb.exists(sub));
+      }
+      case IN -> {
+        @SuppressWarnings({"rawtypes", "unchecked"})
+        Subquery<Object> projected = (Subquery) sub;
+        Path<?> innerSelect = resolvePath(subRoot, subRootType, subRegistry, sc.subSelectField());
+        @SuppressWarnings({"rawtypes", "unchecked"})
+        Expression<Object> innerExpression = (Expression) innerSelect;
+        projected.select(innerExpression);
+        Path<?> outerPath = resolvePath(outer, outerType, outerRegistry, sc.outerField());
+        yield outerPath.in(projected);
+      }
+      case NOT_IN -> {
+        @SuppressWarnings({"rawtypes", "unchecked"})
+        Subquery<Object> projected = (Subquery) sub;
+        Path<?> innerSelect = resolvePath(subRoot, subRootType, subRegistry, sc.subSelectField());
+        @SuppressWarnings({"rawtypes", "unchecked"})
+        Expression<Object> innerExpression = (Expression) innerSelect;
+        projected.select(innerExpression);
+        Path<?> outerPath = resolvePath(outer, outerType, outerRegistry, sc.outerField());
+        yield cb.not(outerPath.in(projected));
+      }
+    };
+  }
+
   private <T> void validateFields(QueryPlan<T> plan) {
     AllowedFieldsPolicy policy = plan.allowedFieldsPolicy();
     if (policy.isAllowAll()) {
@@ -159,6 +263,34 @@ public class QueryPlanSpecificationFactory {
       if (condition instanceof GroupCondition nested) {
         validateFilterFields(policy, nested);
       }
+      if (condition instanceof SubqueryCondition subquery) {
+        validateSubqueryOuterFields(policy, subquery);
+      }
+    }
+  }
+
+  private Path<?> resolvePath(
+      From<?, ?> from, ManagedType<?> fromType, AssociationRegistry registry, String field) {
+    if (from instanceof Root<?> rootFrom) {
+      return pathResolver.resolve(rootFrom, registry, field, JoinMode.LEFT);
+    }
+    return pathResolver.resolve(from, fromType, registry, field, JoinMode.LEFT);
+  }
+
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  private From<?, ?> correlateOuter(Subquery<?> sub, From<?, ?> outer) {
+    if (outer instanceof Root<?> outerRoot) {
+      return sub.correlate((Root) outerRoot);
+    }
+    return sub.correlate((Join) outer);
+  }
+
+  private void validateSubqueryOuterFields(AllowedFieldsPolicy policy, SubqueryCondition subquery) {
+    if (subquery.kind() == SubqueryKind.IN || subquery.kind() == SubqueryKind.NOT_IN) {
+      policy.validateFilter(subquery.outerField());
+    }
+    for (CorrelationPair pair : subquery.correlations()) {
+      policy.validateFilter(pair.outerField());
     }
   }
 }

--- a/specification-repository-jpa/src/main/java/com/borjaglez/specrepository/jpa/support/QueryPlanSpecificationFactory.java
+++ b/specification-repository-jpa/src/main/java/com/borjaglez/specrepository/jpa/support/QueryPlanSpecificationFactory.java
@@ -3,6 +3,7 @@ package com.borjaglez.specrepository.jpa.support;
 import java.util.ArrayList;
 import java.util.List;
 
+import jakarta.persistence.criteria.CommonAbstractCriteria;
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.CriteriaQuery;
 import jakarta.persistence.criteria.Expression;
@@ -112,14 +113,14 @@ public class QueryPlanSpecificationFactory {
       GroupCondition condition,
       From<?, ?> from,
       ManagedType<?> fromType,
-      CriteriaQuery<?> query,
+      CommonAbstractCriteria parent,
       CriteriaBuilder criteriaBuilder,
       AssociationRegistry registry) {
     List<Predicate> predicates = new ArrayList<>();
     for (QueryCondition queryCondition : condition.conditions()) {
       if (queryCondition instanceof GroupCondition groupCondition) {
         Predicate nested =
-            toPredicate(groupCondition, from, fromType, query, criteriaBuilder, registry);
+            toPredicate(groupCondition, from, fromType, parent, criteriaBuilder, registry);
         if (nested != null) {
           predicates.add(nested);
         }
@@ -127,7 +128,8 @@ public class QueryPlanSpecificationFactory {
       }
       if (queryCondition instanceof SubqueryCondition subqueryCondition) {
         predicates.add(
-            translateSubquery(subqueryCondition, from, fromType, query, criteriaBuilder, registry));
+            translateSubquery(
+                subqueryCondition, from, fromType, parent, criteriaBuilder, registry));
         continue;
       }
       PredicateCondition predicateCondition = (PredicateCondition) queryCondition;
@@ -161,15 +163,68 @@ public class QueryPlanSpecificationFactory {
       SubqueryCondition sc,
       From<?, ?> outer,
       ManagedType<?> outerType,
-      CriteriaQuery<?> query,
+      CommonAbstractCriteria parent,
       CriteriaBuilder cb,
       AssociationRegistry outerRegistry) {
-    Subquery<Integer> sub = query.subquery(Integer.class);
-    AssociationRegistry subRegistry = new AssociationRegistry();
-    From<?, ?> subRoot;
-    ManagedType<?> subRootType;
-    Predicate correlationPredicate = null;
+    return switch (sc.kind()) {
+      case EXISTS -> buildExists(sc, outer, outerType, parent, cb, outerRegistry, false);
+      case NOT_EXISTS -> buildExists(sc, outer, outerType, parent, cb, outerRegistry, true);
+      case IN -> buildIn(sc, outer, outerType, parent, cb, outerRegistry, false);
+      case NOT_IN -> buildIn(sc, outer, outerType, parent, cb, outerRegistry, true);
+    };
+  }
 
+  private Predicate buildExists(
+      SubqueryCondition sc,
+      From<?, ?> outer,
+      ManagedType<?> outerType,
+      CommonAbstractCriteria parent,
+      CriteriaBuilder cb,
+      AssociationRegistry outerRegistry,
+      boolean negated) {
+    Subquery<Integer> sub = parent.subquery(Integer.class);
+    AssociationRegistry subRegistry = new AssociationRegistry();
+    SubRootContext context =
+        buildSubRoot(sc, outer, outerType, sub, cb, outerRegistry, subRegistry);
+    applyBody(sc, cb, sub, context, subRegistry);
+    sub.select(cb.literal(1));
+    Predicate existsPredicate = cb.exists(sub);
+    return negated ? cb.not(existsPredicate) : existsPredicate;
+  }
+
+  private <U> Predicate buildIn(
+      SubqueryCondition sc,
+      From<?, ?> outer,
+      ManagedType<?> outerType,
+      CommonAbstractCriteria parent,
+      CriteriaBuilder cb,
+      AssociationRegistry outerRegistry,
+      boolean negated) {
+    Path<?> outerPath = resolvePath(outer, outerType, outerRegistry, sc.outerField());
+    @SuppressWarnings("unchecked")
+    Class<U> projectedType = (Class<U>) outerPath.getJavaType();
+    Subquery<U> sub = parent.subquery(projectedType);
+    AssociationRegistry subRegistry = new AssociationRegistry();
+    SubRootContext context =
+        buildSubRoot(sc, outer, outerType, sub, cb, outerRegistry, subRegistry);
+    applyBody(sc, cb, sub, context, subRegistry);
+    Path<?> innerSelect =
+        resolvePath(context.subRoot(), context.subRootType(), subRegistry, sc.subSelectField());
+    @SuppressWarnings("unchecked")
+    Expression<U> innerExpression = (Expression<U>) innerSelect;
+    sub.select(innerExpression);
+    Predicate inPredicate = outerPath.in(sub);
+    return negated ? cb.not(inPredicate) : inPredicate;
+  }
+
+  private SubRootContext buildSubRoot(
+      SubqueryCondition sc,
+      From<?, ?> outer,
+      ManagedType<?> outerType,
+      Subquery<?> sub,
+      CriteriaBuilder cb,
+      AssociationRegistry outerRegistry,
+      AssociationRegistry subRegistry) {
     if (sc.correlationMode() == CorrelationMode.ASSOCIATION) {
       From<?, ?> correlatedOuter = correlateOuter(sub, outer);
       String[] segments = sc.associationPath().split("\\.");
@@ -180,30 +235,37 @@ public class QueryPlanSpecificationFactory {
         navigated = join;
         currentType = pathResolver.resolveAssociationTarget(currentType, segment);
       }
-      subRoot = navigated;
-      subRootType = currentType;
-    } else {
-      @SuppressWarnings("unchecked")
-      Class<Object> entityClass = (Class<Object>) sc.subEntity();
-      Root<Object> from = sub.from(entityClass);
-      subRoot = from;
-      subRootType = from.getModel();
-      List<Predicate> correlationPredicates = new ArrayList<>();
-      for (CorrelationPair pair : sc.correlations()) {
-        Path<?> outerPath = resolvePath(outer, outerType, outerRegistry, pair.outerField());
-        Path<?> innerPath = resolvePath(subRoot, subRootType, subRegistry, pair.innerField());
-        correlationPredicates.add(cb.equal(innerPath, outerPath));
-      }
-      if (!correlationPredicates.isEmpty()) {
-        correlationPredicate = cb.and(correlationPredicates.toArray(Predicate[]::new));
-      }
+      return new SubRootContext(navigated, currentType, null);
     }
+    @SuppressWarnings("unchecked")
+    Class<Object> entityClass = (Class<Object>) sc.subEntity();
+    Root<Object> from = sub.from(entityClass);
+    ManagedType<?> subRootType = from.getModel();
+    List<Predicate> correlationPredicates = new ArrayList<>();
+    for (CorrelationPair pair : sc.correlations()) {
+      Path<?> outerPath = resolvePath(outer, outerType, outerRegistry, pair.outerField());
+      Path<?> innerPath = resolvePath(from, subRootType, subRegistry, pair.innerField());
+      correlationPredicates.add(cb.equal(innerPath, outerPath));
+    }
+    Predicate correlationPredicate =
+        correlationPredicates.isEmpty()
+            ? null
+            : cb.and(correlationPredicates.toArray(Predicate[]::new));
+    return new SubRootContext(from, subRootType, correlationPredicate);
+  }
 
-    Predicate body = toPredicate(sc.subCondition(), subRoot, subRootType, query, cb, subRegistry);
-
+  private void applyBody(
+      SubqueryCondition sc,
+      CriteriaBuilder cb,
+      Subquery<?> sub,
+      SubRootContext context,
+      AssociationRegistry subRegistry) {
+    Predicate body =
+        toPredicate(
+            sc.subCondition(), context.subRoot(), context.subRootType(), sub, cb, subRegistry);
     List<Predicate> whereParts = new ArrayList<>();
-    if (correlationPredicate != null) {
-      whereParts.add(correlationPredicate);
+    if (context.correlationPredicate() != null) {
+      whereParts.add(context.correlationPredicate());
     }
     if (body != null) {
       whereParts.add(body);
@@ -211,38 +273,10 @@ public class QueryPlanSpecificationFactory {
     if (!whereParts.isEmpty()) {
       sub.where(whereParts.toArray(Predicate[]::new));
     }
-
-    return switch (sc.kind()) {
-      case EXISTS -> {
-        sub.select(cb.literal(1));
-        yield cb.exists(sub);
-      }
-      case NOT_EXISTS -> {
-        sub.select(cb.literal(1));
-        yield cb.not(cb.exists(sub));
-      }
-      case IN -> {
-        @SuppressWarnings({"rawtypes", "unchecked"})
-        Subquery<Object> projected = (Subquery) sub;
-        Path<?> innerSelect = resolvePath(subRoot, subRootType, subRegistry, sc.subSelectField());
-        @SuppressWarnings({"rawtypes", "unchecked"})
-        Expression<Object> innerExpression = (Expression) innerSelect;
-        projected.select(innerExpression);
-        Path<?> outerPath = resolvePath(outer, outerType, outerRegistry, sc.outerField());
-        yield outerPath.in(projected);
-      }
-      case NOT_IN -> {
-        @SuppressWarnings({"rawtypes", "unchecked"})
-        Subquery<Object> projected = (Subquery) sub;
-        Path<?> innerSelect = resolvePath(subRoot, subRootType, subRegistry, sc.subSelectField());
-        @SuppressWarnings({"rawtypes", "unchecked"})
-        Expression<Object> innerExpression = (Expression) innerSelect;
-        projected.select(innerExpression);
-        Path<?> outerPath = resolvePath(outer, outerType, outerRegistry, sc.outerField());
-        yield cb.not(outerPath.in(projected));
-      }
-    };
   }
+
+  private record SubRootContext(
+      From<?, ?> subRoot, ManagedType<?> subRootType, Predicate correlationPredicate) {}
 
   private <T> void validateFields(QueryPlan<T> plan) {
     AllowedFieldsPolicy policy = plan.allowedFieldsPolicy();

--- a/specification-repository-jpa/src/test/java/com/borjaglez/specrepository/jpa/it/ExistsAndSubqueryIntegrationTest.java
+++ b/specification-repository-jpa/src/test/java/com/borjaglez/specrepository/jpa/it/ExistsAndSubqueryIntegrationTest.java
@@ -1,0 +1,257 @@
+package com.borjaglez.specrepository.jpa.it;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.test.context.ContextConfiguration;
+
+import com.borjaglez.specrepository.core.AllowedFieldsPolicy;
+import com.borjaglez.specrepository.core.DisallowedFieldException;
+import com.borjaglez.specrepository.core.Operators;
+import com.borjaglez.specrepository.jpa.SpecificationRepositoryImpl;
+
+@DataJpaTest
+@ContextConfiguration(classes = ExistsAndSubqueryIntegrationTest.TestConfiguration.class)
+class ExistsAndSubqueryIntegrationTest {
+  @Autowired private TestCustomerRepository customers;
+  @Autowired private TestOrderRepository orders;
+
+  @BeforeEach
+  void setUp() {
+    orders.deleteAll();
+    customers.deleteAll();
+
+    TestCustomer borja =
+        new TestCustomer(
+            "Borja", "ACTIVE", 25, LocalDate.of(2024, 1, 10), new TestProfile("Madrid"));
+    borja.addOrder(new TestOrder(new BigDecimal("150.00"), "PAID", true, borja));
+    borja.addOrder(new TestOrder(new BigDecimal("80.00"), "PAID", false, borja));
+
+    TestCustomer lucia =
+        new TestCustomer(
+            "Lucia", "ACTIVE", 32, LocalDate.of(2024, 2, 15), new TestProfile("Barcelona"));
+    lucia.addOrder(new TestOrder(new BigDecimal("20.00"), "CANCELLED", false, lucia));
+
+    TestCustomer john =
+        new TestCustomer(
+            "John", "INACTIVE", 41, LocalDate.of(2024, 3, 20), new TestProfile("Madrid"));
+    john.addOrder(new TestOrder(new BigDecimal("500.00"), "PAID", true, john));
+
+    TestCustomer anna = new TestCustomer("Anna", "ACTIVE", 19, LocalDate.of(2024, 4, 5), null);
+
+    customers.save(borja);
+    customers.save(lucia);
+    customers.save(john);
+    customers.save(anna);
+  }
+
+  @Test
+  void shouldFilterByExistsOnAssociation() {
+    List<TestCustomer> results =
+        customers
+            .query()
+            .<TestOrder>exists("orders", sub -> sub.where("total", Operators.GREATER_THAN, "100"))
+            .findAll();
+
+    assertThat(results)
+        .extracting(TestCustomer::getName)
+        .containsExactlyInAnyOrder("Borja", "John");
+  }
+
+  @Test
+  void shouldFilterByNotExistsOnAssociation() {
+    List<TestCustomer> results =
+        customers
+            .query()
+            .<TestOrder>notExists(
+                "orders", sub -> sub.where("status", Operators.EQUALS, "CANCELLED"))
+            .findAll();
+
+    assertThat(results)
+        .extracting(TestCustomer::getName)
+        .containsExactlyInAnyOrder("Borja", "John", "Anna");
+  }
+
+  @Test
+  void shouldCombineSubqueryWithNormalPredicateInOrGroup() {
+    List<TestCustomer> results =
+        customers
+            .query()
+            .or(
+                group ->
+                    group
+                        .where("status", Operators.EQUALS, "INACTIVE")
+                        .<TestOrder>exists(
+                            "orders", sub -> sub.where("vip", Operators.EQUALS, true)))
+            .findAll();
+
+    assertThat(results)
+        .extracting(TestCustomer::getName)
+        .containsExactlyInAnyOrder("Borja", "John");
+  }
+
+  @Test
+  void shouldFilterByExistsEntityBasedCorrelation() {
+    List<TestCustomer> results =
+        customers
+            .query()
+            .exists(
+                TestOrder.class,
+                sub ->
+                    sub.correlate("id", "customer.id")
+                        .where("status", Operators.EQUALS, "PAID")
+                        .where("vip", Operators.EQUALS, true))
+            .findAll();
+
+    assertThat(results)
+        .extracting(TestCustomer::getName)
+        .containsExactlyInAnyOrder("Borja", "John");
+  }
+
+  @Test
+  void shouldFilterByNotExistsEntityBasedCorrelation() {
+    List<TestCustomer> results =
+        customers
+            .query()
+            .notExists(
+                TestOrder.class,
+                sub ->
+                    sub.correlate("id", "customer.id")
+                        .where("status", Operators.EQUALS, "CANCELLED"))
+            .findAll();
+
+    assertThat(results)
+        .extracting(TestCustomer::getName)
+        .containsExactlyInAnyOrder("Borja", "John", "Anna");
+  }
+
+  @Test
+  void shouldFilterByInSubquery() {
+    List<TestCustomer> results =
+        customers
+            .query()
+            .inSubquery(
+                "id",
+                TestOrder.class,
+                "customer.id",
+                sub -> sub.where("vip", Operators.EQUALS, true))
+            .findAll();
+
+    assertThat(results)
+        .extracting(TestCustomer::getName)
+        .containsExactlyInAnyOrder("Borja", "John");
+  }
+
+  @Test
+  void shouldFilterByNotInSubquery() {
+    List<TestCustomer> results =
+        customers
+            .query()
+            .notInSubquery(
+                "id",
+                TestOrder.class,
+                "customer.id",
+                sub -> sub.where("vip", Operators.EQUALS, true))
+            .findAll();
+
+    assertThat(results)
+        .extracting(TestCustomer::getName)
+        .containsExactlyInAnyOrder("Lucia", "Anna");
+  }
+
+  @Test
+  void shouldHandleNestedGroupInsideSubqueryBody() {
+    List<TestCustomer> results =
+        customers
+            .query()
+            .<TestOrder>exists(
+                "orders",
+                sub ->
+                    sub.or(
+                        group ->
+                            group
+                                .where("total", Operators.GREATER_THAN, "400")
+                                .and(
+                                    inner ->
+                                        inner
+                                            .where("status", Operators.EQUALS, "PAID")
+                                            .where("vip", Operators.EQUALS, false))))
+            .findAll();
+
+    assertThat(results)
+        .extracting(TestCustomer::getName)
+        .containsExactlyInAnyOrder("Borja", "John");
+  }
+
+  @Test
+  void shouldKeepOuterRegistryIsolatedFromSubquery() {
+    List<TestCustomer> results =
+        customers
+            .query()
+            .where("profile.city", Operators.EQUALS, "Madrid")
+            .<TestOrder>exists("orders", sub -> sub.where("status", Operators.EQUALS, "PAID"))
+            .distinct()
+            .findAll();
+
+    assertThat(results)
+        .extracting(TestCustomer::getName)
+        .containsExactlyInAnyOrder("Borja", "John");
+  }
+
+  @Test
+  void shouldRejectDisallowedOuterFieldInCorrelate() {
+    AllowedFieldsPolicy policy = AllowedFieldsPolicy.of(Set.of("name", "status"), Set.of("name"));
+
+    assertThatThrownBy(
+            () ->
+                customers
+                    .query()
+                    .allowedFields(policy)
+                    .exists(
+                        TestOrder.class,
+                        sub ->
+                            sub.correlate("id", "customer.id")
+                                .where("status", Operators.EQUALS, "PAID"))
+                    .findAll())
+        .isInstanceOf(DisallowedFieldException.class)
+        .hasMessageContaining("'id'");
+  }
+
+  @Test
+  void shouldRejectDisallowedOuterFieldInInSubquery() {
+    AllowedFieldsPolicy policy = AllowedFieldsPolicy.of(Set.of("name", "status"), Set.of("name"));
+
+    assertThatThrownBy(
+            () ->
+                customers
+                    .query()
+                    .allowedFields(policy)
+                    .inSubquery(
+                        "id",
+                        TestOrder.class,
+                        "customer.id",
+                        sub -> sub.where("vip", Operators.EQUALS, true))
+                    .findAll())
+        .isInstanceOf(DisallowedFieldException.class)
+        .hasMessageContaining("'id'");
+  }
+
+  @Configuration(proxyBeanMethods = false)
+  @EnableJpaRepositories(
+      basePackageClasses = TestCustomerRepository.class,
+      repositoryBaseClass = SpecificationRepositoryImpl.class)
+  @EntityScan(basePackageClasses = TestCustomer.class)
+  static class TestConfiguration {}
+}

--- a/specification-repository-jpa/src/test/java/com/borjaglez/specrepository/jpa/it/TestCustomer.java
+++ b/specification-repository-jpa/src/test/java/com/borjaglez/specrepository/jpa/it/TestCustomer.java
@@ -1,6 +1,8 @@
 package com.borjaglez.specrepository.jpa.it;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
@@ -8,6 +10,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 
 @Entity
 public class TestCustomer {
@@ -25,6 +28,9 @@ public class TestCustomer {
 
   @ManyToOne(cascade = CascadeType.ALL)
   private TestProfile profile;
+
+  @OneToMany(mappedBy = "customer", cascade = CascadeType.ALL)
+  private List<TestOrder> orders = new ArrayList<>();
 
   public TestCustomer() {}
 
@@ -55,5 +61,17 @@ public class TestCustomer {
 
   public LocalDate getCreatedAt() {
     return createdAt;
+  }
+
+  public Long getId() {
+    return id;
+  }
+
+  public List<TestOrder> getOrders() {
+    return orders;
+  }
+
+  public void addOrder(TestOrder order) {
+    orders.add(order);
   }
 }

--- a/specification-repository-jpa/src/test/java/com/borjaglez/specrepository/jpa/it/TestOrder.java
+++ b/specification-repository-jpa/src/test/java/com/borjaglez/specrepository/jpa/it/TestOrder.java
@@ -1,0 +1,53 @@
+package com.borjaglez.specrepository.jpa.it;
+
+import java.math.BigDecimal;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+
+@Entity
+public class TestOrder {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  private BigDecimal total;
+
+  private String status;
+
+  private boolean vip;
+
+  @ManyToOne private TestCustomer customer;
+
+  public TestOrder() {}
+
+  public TestOrder(BigDecimal total, String status, boolean vip, TestCustomer customer) {
+    this.total = total;
+    this.status = status;
+    this.vip = vip;
+    this.customer = customer;
+  }
+
+  public Long getId() {
+    return id;
+  }
+
+  public BigDecimal getTotal() {
+    return total;
+  }
+
+  public String getStatus() {
+    return status;
+  }
+
+  public boolean isVip() {
+    return vip;
+  }
+
+  public TestCustomer getCustomer() {
+    return customer;
+  }
+}

--- a/specification-repository-jpa/src/test/java/com/borjaglez/specrepository/jpa/it/TestOrderRepository.java
+++ b/specification-repository-jpa/src/test/java/com/borjaglez/specrepository/jpa/it/TestOrderRepository.java
@@ -1,0 +1,5 @@
+package com.borjaglez.specrepository.jpa.it;
+
+import com.borjaglez.specrepository.jpa.SpecificationRepository;
+
+public interface TestOrderRepository extends SpecificationRepository<TestOrder, Long> {}

--- a/specification-repository-jpa/src/test/java/com/borjaglez/specrepository/jpa/support/QueryPlanSpecificationFactoryTest.java
+++ b/specification-repository-jpa/src/test/java/com/borjaglez/specrepository/jpa/support/QueryPlanSpecificationFactoryTest.java
@@ -773,8 +773,8 @@ class QueryPlanSpecificationFactoryTest {
   @Test
   @SuppressWarnings("rawtypes")
   void shouldTranslateInSubqueryWithoutCorrelations() {
-    Subquery<Integer> subqueryMock = mock(Subquery.class);
-    when(query.subquery(Integer.class)).thenReturn(subqueryMock);
+    Subquery<Object> subqueryMock = mock(Subquery.class);
+    when(query.subquery(Object.class)).thenReturn(subqueryMock);
     Root<Object> subRoot = mock(Root.class);
     doReturn(subRoot).when(subqueryMock).from(Object.class);
     EntityType<Object> subEntityType = mock(EntityType.class);
@@ -785,6 +785,7 @@ class QueryPlanSpecificationFactoryTest {
         .when(pathResolver)
         .resolve(eq(subRoot), any(), eq("ref"), eq(JoinMode.LEFT));
     Path<Object> outerField = mock(Path.class);
+    doReturn(Object.class).when(outerField).getJavaType();
     doReturn(outerField).when(pathResolver).resolve(eq(root), any(), eq("id"), eq(JoinMode.LEFT));
     Predicate inPredicate = mock(Predicate.class);
     doReturn(inPredicate).when(outerField).in((Expression<?>) any());
@@ -815,8 +816,8 @@ class QueryPlanSpecificationFactoryTest {
   @Test
   @SuppressWarnings("rawtypes")
   void shouldTranslateNotInSubquery() {
-    Subquery<Integer> subqueryMock = mock(Subquery.class);
-    when(query.subquery(Integer.class)).thenReturn(subqueryMock);
+    Subquery<Object> subqueryMock = mock(Subquery.class);
+    when(query.subquery(Object.class)).thenReturn(subqueryMock);
     Root<Object> subRoot = mock(Root.class);
     doReturn(subRoot).when(subqueryMock).from(Object.class);
     EntityType<Object> subEntityType = mock(EntityType.class);
@@ -827,6 +828,7 @@ class QueryPlanSpecificationFactoryTest {
         .when(pathResolver)
         .resolve(eq(subRoot), any(), eq("ref"), eq(JoinMode.LEFT));
     Path<Object> outerField = mock(Path.class);
+    doReturn(Object.class).when(outerField).getJavaType();
     doReturn(outerField).when(pathResolver).resolve(eq(root), any(), eq("id"), eq(JoinMode.LEFT));
     Predicate inPredicate = mock(Predicate.class);
     doReturn(inPredicate).when(outerField).in((Expression<?>) any());
@@ -861,7 +863,8 @@ class QueryPlanSpecificationFactoryTest {
   void shouldCorrelateJoinWhenNestedSubqueryOuterIsJoin() {
     Subquery<Integer> outerSub = mock(Subquery.class);
     Subquery<Integer> innerSub = mock(Subquery.class);
-    when(query.subquery(Integer.class)).thenReturn(outerSub, innerSub);
+    when(query.subquery(Integer.class)).thenReturn(outerSub);
+    when(outerSub.subquery(Integer.class)).thenReturn(innerSub);
     EntityType<Object> entityType = mock(EntityType.class);
     doReturn(entityType).when(root).getModel();
     Root<Object> outerCorrelated = mock(Root.class);

--- a/specification-repository-jpa/src/test/java/com/borjaglez/specrepository/jpa/support/QueryPlanSpecificationFactoryTest.java
+++ b/specification-repository-jpa/src/test/java/com/borjaglez/specrepository/jpa/support/QueryPlanSpecificationFactoryTest.java
@@ -15,9 +15,13 @@ import java.util.Set;
 
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Expression;
+import jakarta.persistence.criteria.Join;
 import jakarta.persistence.criteria.Path;
 import jakarta.persistence.criteria.Predicate;
 import jakarta.persistence.criteria.Root;
+import jakarta.persistence.criteria.Subquery;
+import jakarta.persistence.metamodel.EntityType;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -25,6 +29,8 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.domain.Specification;
 
 import com.borjaglez.specrepository.core.AllowedFieldsPolicy;
+import com.borjaglez.specrepository.core.CorrelationMode;
+import com.borjaglez.specrepository.core.CorrelationPair;
 import com.borjaglez.specrepository.core.DisallowedFieldException;
 import com.borjaglez.specrepository.core.FetchInstruction;
 import com.borjaglez.specrepository.core.GroupCondition;
@@ -35,6 +41,8 @@ import com.borjaglez.specrepository.core.Operators;
 import com.borjaglez.specrepository.core.PredicateCondition;
 import com.borjaglez.specrepository.core.QueryCondition;
 import com.borjaglez.specrepository.core.QueryPlan;
+import com.borjaglez.specrepository.core.SubqueryCondition;
+import com.borjaglez.specrepository.core.SubqueryKind;
 import com.borjaglez.specrepository.jpa.spi.OperatorContext;
 import com.borjaglez.specrepository.jpa.spi.OperatorHandler;
 
@@ -516,6 +524,391 @@ class QueryPlanSpecificationFactoryTest {
     assertThatExceptionOfType(DisallowedFieldException.class)
         .isThrownBy(() -> factory.create(plan))
         .withMessage("Field 'secret' is not allowed for filtering");
+  }
+
+  @Test
+  void shouldPassValidationWhenSubqueryOuterFieldIsAllowed() {
+    AllowedFieldsPolicy policy = AllowedFieldsPolicy.of(Set.of("id", "name"), Set.of("name"));
+    SubqueryCondition existsCond =
+        new SubqueryCondition(
+            SubqueryKind.EXISTS,
+            CorrelationMode.ENTITY,
+            null,
+            Object.class,
+            List.of(new CorrelationPair("id", "ref")),
+            null,
+            null,
+            new GroupCondition(LogicalOperator.AND, List.of()));
+    SubqueryCondition inCond =
+        new SubqueryCondition(
+            SubqueryKind.IN,
+            CorrelationMode.ENTITY,
+            null,
+            Object.class,
+            List.of(),
+            "id",
+            "ref",
+            new GroupCondition(LogicalOperator.AND, List.of()));
+    SubqueryCondition notInCond =
+        new SubqueryCondition(
+            SubqueryKind.NOT_IN,
+            CorrelationMode.ENTITY,
+            null,
+            Object.class,
+            List.of(),
+            "id",
+            "ref",
+            new GroupCondition(LogicalOperator.AND, List.of()));
+    SubqueryCondition notExistsCond =
+        new SubqueryCondition(
+            SubqueryKind.NOT_EXISTS,
+            CorrelationMode.ENTITY,
+            null,
+            Object.class,
+            List.of(new CorrelationPair("id", "ref")),
+            null,
+            null,
+            new GroupCondition(LogicalOperator.AND, List.of()));
+    GroupCondition rootCondition =
+        new GroupCondition(
+            LogicalOperator.AND,
+            List.of(
+                (QueryCondition) existsCond,
+                (QueryCondition) notExistsCond,
+                (QueryCondition) inCond,
+                (QueryCondition) notInCond));
+    QueryPlan<Object> plan = plan(rootCondition, Sort.unsorted(), policy);
+
+    factory.create(plan);
+  }
+
+  @Test
+  void shouldRejectDisallowedOuterFieldInSubqueryCorrelation() {
+    AllowedFieldsPolicy policy = AllowedFieldsPolicy.of(Set.of("name"), Set.of("name"));
+    SubqueryCondition subquery =
+        new SubqueryCondition(
+            SubqueryKind.EXISTS,
+            CorrelationMode.ENTITY,
+            null,
+            Object.class,
+            List.of(new CorrelationPair("secretId", "ref")),
+            null,
+            null,
+            new GroupCondition(LogicalOperator.AND, List.of()));
+    GroupCondition rootCondition =
+        new GroupCondition(LogicalOperator.AND, List.of((QueryCondition) subquery));
+    QueryPlan<Object> plan = plan(rootCondition, Sort.unsorted(), policy);
+
+    assertThatExceptionOfType(DisallowedFieldException.class)
+        .isThrownBy(() -> factory.create(plan))
+        .withMessage("Field 'secretId' is not allowed for filtering");
+  }
+
+  @Test
+  void shouldRejectDisallowedOuterFieldInInSubquery() {
+    AllowedFieldsPolicy policy = AllowedFieldsPolicy.of(Set.of("name"), Set.of("name"));
+    SubqueryCondition subquery =
+        new SubqueryCondition(
+            SubqueryKind.IN,
+            CorrelationMode.ENTITY,
+            null,
+            Object.class,
+            List.of(),
+            "secretId",
+            "ref",
+            new GroupCondition(LogicalOperator.AND, List.of()));
+    GroupCondition rootCondition =
+        new GroupCondition(LogicalOperator.AND, List.of((QueryCondition) subquery));
+    QueryPlan<Object> plan = plan(rootCondition, Sort.unsorted(), policy);
+
+    assertThatExceptionOfType(DisallowedFieldException.class)
+        .isThrownBy(() -> factory.create(plan))
+        .withMessage("Field 'secretId' is not allowed for filtering");
+  }
+
+  @Test
+  @SuppressWarnings("rawtypes")
+  void shouldTranslateExistsAssociationSubquery() {
+    Subquery<Integer> subqueryMock = mock(Subquery.class);
+    when(query.subquery(Integer.class)).thenReturn(subqueryMock);
+    EntityType<Object> entityType = mock(EntityType.class);
+    doReturn(entityType).when(root).getModel();
+    Root<Object> correlatedRoot = mock(Root.class);
+    doReturn(correlatedRoot).when(subqueryMock).correlate(any(Root.class));
+    Join innerJoin = mock(Join.class);
+    doReturn(innerJoin).when(correlatedRoot).join(eq("orders"), any());
+    doReturn(entityType).when(pathResolver).resolveAssociationTarget(any(), eq("orders"));
+    Expression literal = mock(Expression.class);
+    when(cb.literal(1)).thenReturn(literal);
+    Predicate existsPredicate = mock(Predicate.class);
+    when(cb.exists(subqueryMock)).thenReturn(existsPredicate);
+    when(cb.and(any(Predicate[].class))).thenReturn(existsPredicate);
+
+    SubqueryCondition subquery =
+        new SubqueryCondition(
+            SubqueryKind.EXISTS,
+            CorrelationMode.ASSOCIATION,
+            "orders",
+            null,
+            List.of(),
+            null,
+            null,
+            new GroupCondition(LogicalOperator.AND, List.of()));
+    GroupCondition rootCondition =
+        new GroupCondition(LogicalOperator.AND, List.of((QueryCondition) subquery));
+    QueryPlan<Object> plan = plan(rootCondition);
+
+    Specification<Object> spec = factory.create(plan);
+    Predicate result = spec.toPredicate(root, query, cb);
+
+    assertThat(result).isSameAs(existsPredicate);
+    verify(cb).exists(subqueryMock);
+  }
+
+  @Test
+  @SuppressWarnings("rawtypes")
+  void shouldTranslateNotExistsAssociationSubquery() {
+    Subquery<Integer> outerSub = mock(Subquery.class);
+    when(query.subquery(Integer.class)).thenReturn(outerSub);
+    EntityType<Object> entityType = mock(EntityType.class);
+    doReturn(entityType).when(root).getModel();
+    Root<Object> correlated = mock(Root.class);
+    doReturn(correlated).when(outerSub).correlate(any(Root.class));
+    Join ordersJoin = mock(Join.class);
+    doReturn(ordersJoin).when(correlated).join(eq("orders"), any());
+    doReturn(entityType).when(pathResolver).resolveAssociationTarget(any(), eq("orders"));
+    Expression literal = mock(Expression.class);
+    when(cb.literal(1)).thenReturn(literal);
+    Predicate existsPredicate = mock(Predicate.class);
+    when(cb.exists(outerSub)).thenReturn(existsPredicate);
+    Predicate notExistsPredicate = mock(Predicate.class);
+    when(cb.not(existsPredicate)).thenReturn(notExistsPredicate);
+    when(cb.and(any(Predicate[].class))).thenReturn(notExistsPredicate);
+
+    SubqueryCondition subquery =
+        new SubqueryCondition(
+            SubqueryKind.NOT_EXISTS,
+            CorrelationMode.ASSOCIATION,
+            "orders",
+            null,
+            List.of(),
+            null,
+            null,
+            new GroupCondition(LogicalOperator.AND, List.of()));
+    GroupCondition rootCondition =
+        new GroupCondition(LogicalOperator.AND, List.of((QueryCondition) subquery));
+    QueryPlan<Object> plan = plan(rootCondition);
+
+    Specification<Object> spec = factory.create(plan);
+    Predicate result = spec.toPredicate(root, query, cb);
+
+    assertThat(result).isSameAs(notExistsPredicate);
+    verify(cb).not(existsPredicate);
+  }
+
+  @Test
+  @SuppressWarnings("rawtypes")
+  void shouldTranslateEntitySubqueryWithCorrelationAndBody() {
+    Subquery<Integer> subqueryMock = mock(Subquery.class);
+    when(query.subquery(Integer.class)).thenReturn(subqueryMock);
+    Root<Object> subRoot = mock(Root.class);
+    doReturn(subRoot).when(subqueryMock).from(Object.class);
+    EntityType<Object> subEntityType = mock(EntityType.class);
+    doReturn(subEntityType).when(subRoot).getModel();
+
+    Path<?> outerIdPath = mock(Path.class);
+    doReturn(outerIdPath).when(pathResolver).resolve(eq(root), any(), eq("id"), eq(JoinMode.LEFT));
+    Path<?> innerPath = mock(Path.class);
+    doReturn(innerPath)
+        .when(pathResolver)
+        .resolve(eq(subRoot), any(), eq("customer.id"), eq(JoinMode.LEFT));
+    Path<?> subBodyPath = mock(Path.class);
+    doReturn(String.class).when(subBodyPath).getJavaType();
+    doReturn(subBodyPath)
+        .when(pathResolver)
+        .resolve(eq(subRoot), any(), eq("status"), eq(JoinMode.LEFT));
+    when(valueConversionService.convert("PAID", String.class, Operators.EQUALS)).thenReturn("PAID");
+
+    Predicate eqPair = mock(Predicate.class);
+    when(cb.equal(innerPath, outerIdPath)).thenReturn(eqPair);
+    Predicate innerEqPredicate = mock(Predicate.class);
+    OperatorHandler eqHandler = mock(OperatorHandler.class);
+    when(operatorRegistry.get(Operators.EQUALS)).thenReturn(eqHandler);
+    when(eqHandler.create(any(OperatorContext.class))).thenReturn(innerEqPredicate);
+    Predicate correlationPredicate = mock(Predicate.class);
+    Predicate bodyPredicate = mock(Predicate.class);
+    when(cb.and(new Predicate[] {eqPair})).thenReturn(correlationPredicate);
+    when(cb.and(new Predicate[] {innerEqPredicate})).thenReturn(bodyPredicate);
+    Expression literal = mock(Expression.class);
+    when(cb.literal(1)).thenReturn(literal);
+    Predicate existsPredicate = mock(Predicate.class);
+    when(cb.exists(subqueryMock)).thenReturn(existsPredicate);
+    Predicate outerCombined = mock(Predicate.class);
+    when(cb.and(new Predicate[] {existsPredicate})).thenReturn(outerCombined);
+
+    SubqueryCondition subquery =
+        new SubqueryCondition(
+            SubqueryKind.EXISTS,
+            CorrelationMode.ENTITY,
+            null,
+            Object.class,
+            List.of(new CorrelationPair("id", "customer.id")),
+            null,
+            null,
+            new GroupCondition(
+                LogicalOperator.AND,
+                List.of(new PredicateCondition("status", Operators.EQUALS, "PAID", false, false))));
+    GroupCondition rootCondition =
+        new GroupCondition(LogicalOperator.AND, List.of((QueryCondition) subquery));
+    QueryPlan<Object> plan = plan(rootCondition);
+
+    Specification<Object> spec = factory.create(plan);
+    Predicate result = spec.toPredicate(root, query, cb);
+
+    assertThat(result).isSameAs(outerCombined);
+    verify(subqueryMock).where(any(Predicate[].class));
+    verify(subqueryMock).select(literal);
+  }
+
+  @Test
+  @SuppressWarnings("rawtypes")
+  void shouldTranslateInSubqueryWithoutCorrelations() {
+    Subquery<Integer> subqueryMock = mock(Subquery.class);
+    when(query.subquery(Integer.class)).thenReturn(subqueryMock);
+    Root<Object> subRoot = mock(Root.class);
+    doReturn(subRoot).when(subqueryMock).from(Object.class);
+    EntityType<Object> subEntityType = mock(EntityType.class);
+    doReturn(subEntityType).when(subRoot).getModel();
+
+    Path<Object> innerSelect = mock(Path.class);
+    doReturn(innerSelect)
+        .when(pathResolver)
+        .resolve(eq(subRoot), any(), eq("ref"), eq(JoinMode.LEFT));
+    Path<Object> outerField = mock(Path.class);
+    doReturn(outerField).when(pathResolver).resolve(eq(root), any(), eq("id"), eq(JoinMode.LEFT));
+    Predicate inPredicate = mock(Predicate.class);
+    doReturn(inPredicate).when(outerField).in((Expression<?>) any());
+    Predicate outerCombined = mock(Predicate.class);
+    when(cb.and(any(Predicate[].class))).thenReturn(outerCombined);
+
+    SubqueryCondition subquery =
+        new SubqueryCondition(
+            SubqueryKind.IN,
+            CorrelationMode.ENTITY,
+            null,
+            Object.class,
+            List.of(),
+            "id",
+            "ref",
+            new GroupCondition(LogicalOperator.AND, List.of()));
+    GroupCondition rootCondition =
+        new GroupCondition(LogicalOperator.AND, List.of((QueryCondition) subquery));
+    QueryPlan<Object> plan = plan(rootCondition);
+
+    Specification<Object> spec = factory.create(plan);
+    Predicate result = spec.toPredicate(root, query, cb);
+
+    assertThat(result).isSameAs(outerCombined);
+    verify(subqueryMock).select(any(Expression.class));
+  }
+
+  @Test
+  @SuppressWarnings("rawtypes")
+  void shouldTranslateNotInSubquery() {
+    Subquery<Integer> subqueryMock = mock(Subquery.class);
+    when(query.subquery(Integer.class)).thenReturn(subqueryMock);
+    Root<Object> subRoot = mock(Root.class);
+    doReturn(subRoot).when(subqueryMock).from(Object.class);
+    EntityType<Object> subEntityType = mock(EntityType.class);
+    doReturn(subEntityType).when(subRoot).getModel();
+
+    Path<Object> innerSelect = mock(Path.class);
+    doReturn(innerSelect)
+        .when(pathResolver)
+        .resolve(eq(subRoot), any(), eq("ref"), eq(JoinMode.LEFT));
+    Path<Object> outerField = mock(Path.class);
+    doReturn(outerField).when(pathResolver).resolve(eq(root), any(), eq("id"), eq(JoinMode.LEFT));
+    Predicate inPredicate = mock(Predicate.class);
+    doReturn(inPredicate).when(outerField).in((Expression<?>) any());
+    Predicate notInPredicate = mock(Predicate.class);
+    when(cb.not(inPredicate)).thenReturn(notInPredicate);
+    Predicate outerCombined = mock(Predicate.class);
+    when(cb.and(any(Predicate[].class))).thenReturn(outerCombined);
+
+    SubqueryCondition subquery =
+        new SubqueryCondition(
+            SubqueryKind.NOT_IN,
+            CorrelationMode.ENTITY,
+            null,
+            Object.class,
+            List.of(),
+            "id",
+            "ref",
+            new GroupCondition(LogicalOperator.AND, List.of()));
+    GroupCondition rootCondition =
+        new GroupCondition(LogicalOperator.AND, List.of((QueryCondition) subquery));
+    QueryPlan<Object> plan = plan(rootCondition);
+
+    Specification<Object> spec = factory.create(plan);
+    Predicate result = spec.toPredicate(root, query, cb);
+
+    assertThat(result).isSameAs(outerCombined);
+    verify(cb).not(inPredicate);
+  }
+
+  @Test
+  @SuppressWarnings("rawtypes")
+  void shouldCorrelateJoinWhenNestedSubqueryOuterIsJoin() {
+    Subquery<Integer> outerSub = mock(Subquery.class);
+    Subquery<Integer> innerSub = mock(Subquery.class);
+    when(query.subquery(Integer.class)).thenReturn(outerSub, innerSub);
+    EntityType<Object> entityType = mock(EntityType.class);
+    doReturn(entityType).when(root).getModel();
+    Root<Object> outerCorrelated = mock(Root.class);
+    doReturn(outerCorrelated).when(outerSub).correlate(any(Root.class));
+    Join<?, ?> outerAssocJoin = mock(Join.class);
+    doReturn(outerAssocJoin).when(outerCorrelated).join(eq("orders"), any());
+    doReturn(entityType).when(pathResolver).resolveAssociationTarget(any(), eq("orders"));
+    Join<?, ?> innerCorrelated = mock(Join.class);
+    doReturn(innerCorrelated).when(innerSub).correlate(any(Join.class));
+    doReturn(mock(Join.class)).when(innerCorrelated).join(eq("items"), any());
+    doReturn(entityType).when(pathResolver).resolveAssociationTarget(any(), eq("items"));
+    Expression literal = mock(Expression.class);
+    when(cb.literal(1)).thenReturn(literal);
+    Predicate existsInner = mock(Predicate.class);
+    when(cb.exists(innerSub)).thenReturn(existsInner);
+    when(cb.and(any(Predicate[].class))).thenReturn(existsInner);
+    Predicate existsOuter = mock(Predicate.class);
+    when(cb.exists(outerSub)).thenReturn(existsOuter);
+
+    SubqueryCondition innerCond =
+        new SubqueryCondition(
+            SubqueryKind.EXISTS,
+            CorrelationMode.ASSOCIATION,
+            "items",
+            null,
+            List.of(),
+            null,
+            null,
+            new GroupCondition(LogicalOperator.AND, List.of()));
+    SubqueryCondition outerCond =
+        new SubqueryCondition(
+            SubqueryKind.EXISTS,
+            CorrelationMode.ASSOCIATION,
+            "orders",
+            null,
+            List.of(),
+            null,
+            null,
+            new GroupCondition(LogicalOperator.AND, List.of((QueryCondition) innerCond)));
+    GroupCondition rootCondition =
+        new GroupCondition(LogicalOperator.AND, List.of((QueryCondition) outerCond));
+    QueryPlan<Object> plan = plan(rootCondition);
+
+    Specification<Object> spec = factory.create(plan);
+    spec.toPredicate(root, query, cb);
+
+    verify(innerSub).correlate(any(Join.class));
   }
 
   @Test


### PR DESCRIPTION
Closes #23.

## Summary
- New fluent DSL entry points on `ConditionGroupBuilder` / `QueryPlanBuilder` / `SpecificationExecutableQuery`: `exists`, `notExists`, `inSubquery`, `notInSubquery`, with both association-based and entity-based correlation.
- Core model: new sealed `SubqueryCondition` variant (`SubqueryKind`, `CorrelationMode`, `CorrelationPair`) and a `SubqueryBuilder<S>` that reuses the existing condition builder primitives (`where`, `and`, `or`, `correlate`).
- JPA translator (`QueryPlanSpecificationFactory`) threads `CriteriaQuery` through `toPredicate` and dispatches `SubqueryCondition` into a dedicated `translateSubquery` that emits `cb.exists(...)` / `cb.not(cb.exists(...))` or `path.in(subquery)` with correlated semantics. Path resolution now also walks arbitrary `From<?, ?>` + `ManagedType<?>` for sub-roots.
- `AllowedFieldsPolicy` validates outer fields referenced by subqueries (the `outerField` of `inSubquery` and every `correlate(...)` outer side). Inner fields are documented as out of scope for this iteration.
- `docs/subqueries.md` with API, correlation semantics, limitations, GraalVM note. README gains a dedicated "EXISTS and Subqueries" section.

## Why EXISTS and not just `where`?
A plain `where("orders.status", NOT_EQUALS, "CANCELLED")` cannot express "customer with zero cancelled orders" correctly, and filtering on `*-to-many` associations forces `distinct()` + breaks pagination. `EXISTS` / `NOT EXISTS` fix both, and `IN (subquery)` enables cross-entity membership without mapping an association purely for the filter.

## Test plan
- [x] `./gradlew quality` (full CI pipeline: tests + 100% line+branch coverage in core and jpa + spotless)
- [x] `ExistsAndSubqueryIntegrationTest` (11 scenarios: association/entity EXISTS + NOT EXISTS, IN/NOT IN subquery, nested AND/OR inside sub-body, `distinct` + outer fetch isolation, outer `AllowedFieldsPolicy` rejection for correlate and `inSubquery`)
- [x] Unit tests in `QueryPlanSpecificationFactoryTest` for dispatch, IN/NOT_IN, entity correlation pairs, and nested subquery (`correlateOuter` Join branch)
- [x] Core unit tests for `SubqueryCondition` constructor validation, `CorrelationPair`, `ConditionGroupBuilder` and `QueryPlanBuilder` subquery fluent methods