### PR TITLE
feat(jpa): add Slice pagination and document keyset as follow-up

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,21 @@ Page<Product> page = productRepository.query()
 
 When using `Pageable`, its sort takes priority over any sort set on the builder.
 
+For large datasets where the total row count is expensive and unnecessary, the
+DSL also exposes `findSlice(Pageable)` returning Spring Data's `Slice<T>`. It
+fetches `pageSize + 1` rows in a single query, sets `hasNext` accordingly, and
+skips the `COUNT(*)` query that `findAll(Pageable)` runs:
+
+```java
+Slice<Product> slice = productRepository.query()
+    .where("status", Operators.NOT_EQUALS, "DISCONTINUED")
+    .sort(Sort.by(Sort.Direction.DESC, "createdAt"))
+    .findSlice(PageRequest.of(0, 10));
+```
+
+See [docs/pagination.md](docs/pagination.md) for the full `Page` vs `Slice`
+comparison and a design note on keyset pagination.
+
 ### Grouped Counts
 
 `groupBy(...)` is applied to the underlying JPA Criteria query, so grouped counts honor the same

--- a/docs/pagination.md
+++ b/docs/pagination.md
@@ -1,0 +1,141 @@
+# Pagination
+
+The DSL exposes two pagination contracts on the fluent query, both backed by
+Spring Data's `Pageable` argument:
+
+- `findAll(Pageable)` returns `Page<T>` — content + total row count.
+- `findSlice(Pageable)` returns `Slice<T>` — content + `hasNext` flag, no
+  total count.
+
+Both honor the same sort priority: when the supplied `Pageable` is sorted, its
+`Sort` overrides any `sort(...)` set on the builder; otherwise the builder's
+sort is used.
+
+## `findAll(Pageable)` — counted pagination
+
+```java
+Page<Product> page = productRepository.query()
+    .where("status", Operators.EQUALS, "ACTIVE")
+    .sort(Sort.by("name"))
+    .findAll(PageRequest.of(0, 20));
+
+page.getTotalElements();  // 12_345
+page.getTotalPages();     // 618
+page.hasNext();           // true
+```
+
+Translates to **two SQL queries**:
+
+1. `SELECT ... FROM ... WHERE ... ORDER BY ... LIMIT 20 OFFSET 0`
+2. `SELECT COUNT(*) FROM ... WHERE ...`
+
+Use it when callers need to render "page X of Y" controls or report a total
+count to the user.
+
+## `findSlice(Pageable)` — windowed pagination
+
+```java
+Slice<Product> slice = productRepository.query()
+    .where("status", Operators.EQUALS, "ACTIVE")
+    .sort(Sort.by("name"))
+    .findSlice(PageRequest.of(0, 20));
+
+slice.getContent();   // up to 20 elements
+slice.hasNext();      // true if more rows exist
+```
+
+Translates to **one SQL query** that fetches `pageSize + 1` rows:
+
+```sql
+SELECT ... FROM ... WHERE ... ORDER BY ... LIMIT 21 OFFSET 0
+```
+
+If 21 rows come back, `hasNext` is `true` and the 21st row is dropped before
+the `Slice` is returned. If fewer than `pageSize + 1` come back, `hasNext` is
+`false`.
+
+Use it when:
+
+- The result set is large and the `COUNT(*)` is expensive (full table scans,
+  joins on big tables, group-by counts).
+- The UI only needs "next" / "previous" controls, not a total page count.
+- A REST endpoint streams pages to a client that already knows how to detect
+  the end via `hasNext`.
+
+`findSlice` works for the same shapes as `findAll(Pageable)`:
+
+- entity results,
+- DTO and record projections via `selectInto(...)`,
+- field projections via `select(...)`,
+- aggregate / `groupBy` queries.
+
+## `Page` vs `Slice` — when to use what
+
+| Aspect                       | `findAll(Pageable)` → `Page` | `findSlice(Pageable)` → `Slice` |
+|------------------------------|------------------------------|---------------------------------|
+| SQL queries                  | 2 (data + count)             | 1 (data only, fetches `pageSize + 1`) |
+| Total row count              | yes                          | no                              |
+| `hasNext` / `hasPrevious`    | yes                          | yes                             |
+| Random access (jump to page) | yes                          | yes (offset-based)              |
+| Cost on large tables         | dominated by `COUNT(*)`      | one extra row per page          |
+| Best fit                     | UIs with "page X of Y"       | infinite scroll, large exports, count-less APIs |
+
+## Keyset pagination — design note (not yet implemented)
+
+Both `Page` and `Slice` are *offset-based*: behind the scenes JPA issues
+`OFFSET n LIMIT m`, which forces the database to scan and discard the first
+`n` rows on every request. For large `n` this becomes O(offset) and
+dominates the cost of the query, even with `findSlice`.
+
+**Keyset pagination** (a.k.a. seek pagination) avoids the offset entirely by
+remembering the last row's sort key from the previous page and translating
+"give me the next page" into a compound predicate:
+
+```sql
+SELECT ... FROM products
+WHERE (created_at, id) > (:lastCreatedAt, :lastId)
+ORDER BY created_at, id
+LIMIT 21
+```
+
+This is O(log n) on a properly indexed `(created_at, id)` and stays constant
+as the dataset grows.
+
+### Why it is not implemented yet
+
+A keyset implementation needs more than a Slice constructor:
+
+- A **stable, total ordering** is required. The sort columns must end with a
+  unique tiebreaker (typically the primary key); otherwise the comparison can
+  skip or duplicate rows.
+- A **cursor token** must encode the last row's sort-key tuple in a form the
+  caller can persist between requests (typically base64-encoded JSON or a
+  signed token).
+- The **DSL surface** must let the caller pass that cursor in, and the
+  translator must turn it into a compound `(col1, col2, ...) > (val1, val2, ...)`
+  predicate. Spring Data Commons does not have a portable abstraction for this
+  — it has to be built in this library.
+- Some **operator semantics change**: descending sort needs `<` instead of
+  `>`, mixed asc/desc needs row constructors that not every JPA dialect
+  supports cleanly.
+
+That is a meaningful amount of design and a separate change from the
+single-method `Slice` addition. Because of that, keyset pagination is
+documented here but **deferred to a follow-up issue**.
+
+### Proposed shape (subject to change)
+
+```java
+Slice<Product> slice = productRepository.query()
+    .where("status", Operators.EQUALS, "ACTIVE")
+    .sort(Sort.by("createdAt", "id"))
+    .keysetAfter(previousCursor)   // encoded last-row tuple, may be null
+    .findSlice(PageRequest.ofSize(20));
+
+String nextCursor = encodeCursor(slice.getContent().getLast());
+```
+
+The terminal would still return a `Slice<T>` so callers do not need a third
+return type, and the cursor format would be opaque to the caller. The
+follow-up will define cursor encoding, allowed sort shapes, and the
+interaction with `AllowedFieldsPolicy`.

--- a/specification-repository-jpa/src/main/java/com/borjaglez/specrepository/jpa/ProjectedSpecificationExecutableQuery.java
+++ b/specification-repository-jpa/src/main/java/com/borjaglez/specrepository/jpa/ProjectedSpecificationExecutableQuery.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 
 import com.borjaglez.specrepository.core.ProjectedQueryPlanBuilder;
 import com.borjaglez.specrepository.core.QueryPlan;
@@ -24,6 +25,10 @@ public class ProjectedSpecificationExecutableQuery<T, P> extends ProjectedQueryP
 
   public Page<P> findAll(Pageable pageable) {
     return repository.findAllProjected(build(), pageable);
+  }
+
+  public Slice<P> findSlice(Pageable pageable) {
+    return repository.findSliceProjected(build(), pageable);
   }
 
   public Optional<P> findOne() {

--- a/specification-repository-jpa/src/main/java/com/borjaglez/specrepository/jpa/SpecificationExecutableQuery.java
+++ b/specification-repository-jpa/src/main/java/com/borjaglez/specrepository/jpa/SpecificationExecutableQuery.java
@@ -6,6 +6,7 @@ import java.util.function.Consumer;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
 
 import com.borjaglez.specrepository.core.AllowedFieldsPolicy;
@@ -210,6 +211,10 @@ public class SpecificationExecutableQuery<T> extends QueryPlanBuilder<T> {
 
   public Page<T> findAll(Pageable pageable) {
     return repository.findAll(build(), pageable);
+  }
+
+  public Slice<T> findSlice(Pageable pageable) {
+    return repository.findSlice(build(), pageable);
   }
 
   public Optional<T> findOne() {

--- a/specification-repository-jpa/src/main/java/com/borjaglez/specrepository/jpa/SpecificationRepository.java
+++ b/specification-repository-jpa/src/main/java/com/borjaglez/specrepository/jpa/SpecificationRepository.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.repository.NoRepositoryBean;
@@ -26,6 +27,13 @@ public interface SpecificationRepository<T, ID>
   Page<T> findAll(QueryPlan<T> plan, Pageable pageable);
 
   default <P> Page<P> findAllProjected(QueryPlan<T> plan, Pageable pageable) {
+    throw new UnsupportedOperationException(
+        "Projected queries are not supported by this repository");
+  }
+
+  Slice<T> findSlice(QueryPlan<T> plan, Pageable pageable);
+
+  default <P> Slice<P> findSliceProjected(QueryPlan<T> plan, Pageable pageable) {
     throw new UnsupportedOperationException(
         "Projected queries are not supported by this repository");
   }

--- a/specification-repository-jpa/src/main/java/com/borjaglez/specrepository/jpa/SpecificationRepositoryImpl.java
+++ b/specification-repository-jpa/src/main/java/com/borjaglez/specrepository/jpa/SpecificationRepositoryImpl.java
@@ -126,7 +126,7 @@ public class SpecificationRepositoryImpl<T, ID extends Serializable>
 
   @Override
   public <P> Slice<P> findSliceProjected(QueryPlan<T> plan, Pageable pageable) {
-    List<P> fetched = executeProjectedSliceQuery(plan, pageable, requiredProjectionType(plan));
+    List<P> fetched = executeProjectedQuery(plan, pageable, requiredProjectionType(plan), 1);
     return toSlice(fetched, pageable);
   }
 
@@ -225,11 +225,11 @@ public class SpecificationRepositoryImpl<T, ID extends Serializable>
 
   private <P> List<P> executeProjectedQuery(
       QueryPlan<T> plan, Pageable pageable, Class<P> resultType) {
-    return executeProjectedQuery(plan, pageable, resultType, null);
+    return executeProjectedQuery(plan, pageable, resultType, 0);
   }
 
   private <P> List<P> executeProjectedQuery(
-      QueryPlan<T> plan, Pageable pageable, Class<P> resultType, Integer maxResults) {
+      QueryPlan<T> plan, Pageable pageable, Class<P> resultType, int extraLimit) {
     CriteriaBuilder builder = entityManager.getCriteriaBuilder();
     CriteriaQuery<P> query = builder.createQuery(resultType);
     Root<T> root = query.from(getDomainClass());
@@ -240,25 +240,10 @@ public class SpecificationRepositoryImpl<T, ID extends Serializable>
     TypedQuery<P> typedQuery = entityManager.createQuery(query);
     if (pageable != null) {
       typedQuery.setFirstResult((int) pageable.getOffset());
-      typedQuery.setMaxResults(pageable.getPageSize());
-    } else if (maxResults != null) {
-      typedQuery.setMaxResults(maxResults);
+      typedQuery.setMaxResults(pageable.getPageSize() + extraLimit);
+    } else if (extraLimit > 0) {
+      typedQuery.setMaxResults(extraLimit);
     }
-    return typedQuery.getResultList();
-  }
-
-  private <P> List<P> executeProjectedSliceQuery(
-      QueryPlan<T> plan, Pageable pageable, Class<P> resultType) {
-    CriteriaBuilder builder = entityManager.getCriteriaBuilder();
-    CriteriaQuery<P> query = builder.createQuery(resultType);
-    Root<T> root = query.from(getDomainClass());
-    specificationFactory.create(plan).toPredicate(root, query, builder);
-    applyProjection(plan, builder, root, query, resultType);
-    applySort(plan, pageable, builder, root, query);
-
-    TypedQuery<P> typedQuery = entityManager.createQuery(query);
-    typedQuery.setFirstResult((int) pageable.getOffset());
-    typedQuery.setMaxResults(pageable.getPageSize() + 1);
     return typedQuery.getResultList();
   }
 

--- a/specification-repository-jpa/src/main/java/com/borjaglez/specrepository/jpa/SpecificationRepositoryImpl.java
+++ b/specification-repository-jpa/src/main/java/com/borjaglez/specrepository/jpa/SpecificationRepositoryImpl.java
@@ -18,6 +18,8 @@ import jakarta.persistence.criteria.Selection;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
 import org.springframework.data.jpa.repository.query.QueryUtils;
 import org.springframework.data.jpa.repository.support.JpaEntityInformation;
 import org.springframework.data.jpa.repository.support.SimpleJpaRepository;
@@ -95,9 +97,40 @@ public class SpecificationRepositoryImpl<T, ID extends Serializable>
       return (Page<T>) findAllProjected(plan, pageable);
     }
     if (plan.hasSelections()) {
-      List<?> content = executeProjectedQuery(plan, pageable);
+      List<?> content = executeProjectedQuery(plan, pageable, 0);
       return new PageImpl<>((List<T>) content, pageable, countSelectedRows(plan));
     }
+    List<T> content = fetchEntityPage(plan, pageable, 0);
+    return new PageImpl<>(content, pageable, count(plan));
+  }
+
+  @Override
+  public <P> Page<P> findAllProjected(QueryPlan<T> plan, Pageable pageable) {
+    List<P> content = executeProjectedQuery(plan, pageable, requiredProjectionType(plan));
+    return new PageImpl<>(content, pageable, countSelectedRows(plan));
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public Slice<T> findSlice(QueryPlan<T> plan, Pageable pageable) {
+    if (plan.projectionType() != null) {
+      return (Slice<T>) findSliceProjected(plan, pageable);
+    }
+    if (plan.hasSelections()) {
+      List<?> fetched = executeProjectedQuery(plan, pageable, 1);
+      return toSlice((List<T>) fetched, pageable);
+    }
+    List<T> fetched = fetchEntityPage(plan, pageable, 1);
+    return toSlice(fetched, pageable);
+  }
+
+  @Override
+  public <P> Slice<P> findSliceProjected(QueryPlan<T> plan, Pageable pageable) {
+    List<P> fetched = executeProjectedSliceQuery(plan, pageable, requiredProjectionType(plan));
+    return toSlice(fetched, pageable);
+  }
+
+  private List<T> fetchEntityPage(QueryPlan<T> plan, Pageable pageable, int extraLimit) {
     CriteriaBuilder builder = entityManager.getCriteriaBuilder();
     CriteriaQuery<T> query = builder.createQuery(getDomainClass());
     Root<T> root = query.from(getDomainClass());
@@ -110,14 +143,15 @@ public class SpecificationRepositoryImpl<T, ID extends Serializable>
     }
     TypedQuery<T> typedQuery = entityManager.createQuery(query);
     typedQuery.setFirstResult((int) pageable.getOffset());
-    typedQuery.setMaxResults(pageable.getPageSize());
-    return new PageImpl<>(typedQuery.getResultList(), pageable, count(plan));
+    typedQuery.setMaxResults(pageable.getPageSize() + extraLimit);
+    return typedQuery.getResultList();
   }
 
-  @Override
-  public <P> Page<P> findAllProjected(QueryPlan<T> plan, Pageable pageable) {
-    List<P> content = executeProjectedQuery(plan, pageable, requiredProjectionType(plan));
-    return new PageImpl<>(content, pageable, countSelectedRows(plan));
+  private <R> Slice<R> toSlice(List<R> fetched, Pageable pageable) {
+    int pageSize = pageable.getPageSize();
+    boolean hasNext = fetched.size() > pageSize;
+    List<R> content = hasNext ? new ArrayList<>(fetched.subList(0, pageSize)) : fetched;
+    return new SliceImpl<>(content, pageable, hasNext);
   }
 
   @Override
@@ -167,6 +201,10 @@ public class SpecificationRepositoryImpl<T, ID extends Serializable>
   }
 
   private List<?> executeProjectedQuery(QueryPlan<T> plan, Pageable pageable) {
+    return executeProjectedQuery(plan, pageable, 0);
+  }
+
+  private List<?> executeProjectedQuery(QueryPlan<T> plan, Pageable pageable, int extraLimit) {
     CriteriaBuilder builder = entityManager.getCriteriaBuilder();
     CriteriaQuery<?> query =
         plan.selections().size() == 1
@@ -180,7 +218,7 @@ public class SpecificationRepositoryImpl<T, ID extends Serializable>
     TypedQuery<?> typedQuery = entityManager.createQuery(query);
     if (pageable != null) {
       typedQuery.setFirstResult((int) pageable.getOffset());
-      typedQuery.setMaxResults(pageable.getPageSize());
+      typedQuery.setMaxResults(pageable.getPageSize() + extraLimit);
     }
     return typedQuery.getResultList();
   }
@@ -206,6 +244,21 @@ public class SpecificationRepositoryImpl<T, ID extends Serializable>
     } else if (maxResults != null) {
       typedQuery.setMaxResults(maxResults);
     }
+    return typedQuery.getResultList();
+  }
+
+  private <P> List<P> executeProjectedSliceQuery(
+      QueryPlan<T> plan, Pageable pageable, Class<P> resultType) {
+    CriteriaBuilder builder = entityManager.getCriteriaBuilder();
+    CriteriaQuery<P> query = builder.createQuery(resultType);
+    Root<T> root = query.from(getDomainClass());
+    specificationFactory.create(plan).toPredicate(root, query, builder);
+    applyProjection(plan, builder, root, query, resultType);
+    applySort(plan, pageable, builder, root, query);
+
+    TypedQuery<P> typedQuery = entityManager.createQuery(query);
+    typedQuery.setFirstResult((int) pageable.getOffset());
+    typedQuery.setMaxResults(pageable.getPageSize() + 1);
     return typedQuery.getResultList();
   }
 

--- a/specification-repository-jpa/src/test/java/com/borjaglez/specrepository/jpa/SpecificationRepositoryImplTest.java
+++ b/specification-repository-jpa/src/test/java/com/borjaglez/specrepository/jpa/SpecificationRepositoryImplTest.java
@@ -64,6 +64,13 @@ class SpecificationRepositoryImplTest {
   }
 
   @Test
+  void shouldRejectProjectedFindSliceWhenRepositoryDoesNotSupportIt() {
+    assertThatThrownBy(() -> repository.findSliceProjected(projectedPlan(), PageRequest.of(0, 1)))
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessage("Projected queries are not supported by this repository");
+  }
+
+  @Test
   void shouldRejectProjectedFindOneWhenRepositoryDoesNotSupportIt() {
     assertThatThrownBy(() -> repository.findOneProjected(projectedPlan()))
         .isInstanceOf(UnsupportedOperationException.class)

--- a/specification-repository-jpa/src/test/java/com/borjaglez/specrepository/jpa/it/SpecificationRepositoryIntegrationTest.java
+++ b/specification-repository-jpa/src/test/java/com/borjaglez/specrepository/jpa/it/SpecificationRepositoryIntegrationTest.java
@@ -811,6 +811,21 @@ class SpecificationRepositoryIntegrationTest {
   }
 
   @Test
+  void shouldFindSliceWithQueryPlan() {
+    QueryPlan<TestCustomer> plan =
+        repository
+            .query()
+            .where("status", Operators.IS_NOT_NULL, null)
+            .sort(Sort.by("name"))
+            .plan();
+
+    Slice<TestCustomer> slice = repository.findSlice(plan, PageRequest.of(0, 2));
+
+    assertThat(slice.getContent()).hasSize(2);
+    assertThat(slice.hasNext()).isTrue();
+  }
+
+  @Test
   @SuppressWarnings({"rawtypes", "unchecked"})
   void shouldFindSliceWithProjectedQueryPlanMetadata() {
     QueryPlan<TestCustomer> plan =

--- a/specification-repository-jpa/src/test/java/com/borjaglez/specrepository/jpa/it/SpecificationRepositoryIntegrationTest.java
+++ b/specification-repository-jpa/src/test/java/com/borjaglez/specrepository/jpa/it/SpecificationRepositoryIntegrationTest.java
@@ -16,6 +16,7 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.test.context.ContextConfiguration;
@@ -314,6 +315,110 @@ class SpecificationRepositoryIntegrationTest {
     assertThat(page.getContent()).hasSize(2);
     assertThat(page.getTotalElements()).isEqualTo(3);
     assertThat(page.getTotalPages()).isEqualTo(2);
+  }
+
+  // -- Slice pagination (no count query) --
+
+  @Test
+  void shouldSliceResultsWithNextPage() {
+    Slice<TestCustomer> slice =
+        repository
+            .query()
+            .where("status", Operators.IS_NOT_NULL, null)
+            .sort(Sort.by("name"))
+            .findSlice(PageRequest.of(0, 2));
+
+    assertThat(slice.getContent())
+        .extracting(TestCustomer::getName)
+        .containsExactly("Borja", "John");
+    assertThat(slice.hasNext()).isTrue();
+    assertThat(slice.getNumberOfElements()).isEqualTo(2);
+  }
+
+  @Test
+  void shouldSliceLastPage() {
+    Slice<TestCustomer> slice =
+        repository
+            .query()
+            .where("status", Operators.IS_NOT_NULL, null)
+            .sort(Sort.by("name"))
+            .findSlice(PageRequest.of(1, 2));
+
+    assertThat(slice.getContent()).extracting(TestCustomer::getName).containsExactly("Lucia");
+    assertThat(slice.hasNext()).isFalse();
+  }
+
+  @Test
+  void shouldSliceEmptyResults() {
+    Slice<TestCustomer> slice =
+        repository
+            .query()
+            .where("status", Operators.EQUALS, "NOPE")
+            .findSlice(PageRequest.of(0, 5));
+
+    assertThat(slice.getContent()).isEmpty();
+    assertThat(slice.hasNext()).isFalse();
+  }
+
+  @Test
+  void shouldSliceUsingPageableSortOverridingPlanSort() {
+    Slice<TestCustomer> slice =
+        repository
+            .query()
+            .where("status", Operators.EQUALS, "ACTIVE")
+            .sort(Sort.by(Sort.Direction.ASC, "name"))
+            .findSlice(PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "name")));
+
+    assertThat(slice.getContent())
+        .extracting(TestCustomer::getName)
+        .containsExactly("Lucia", "Borja");
+    assertThat(slice.hasNext()).isFalse();
+  }
+
+  @Test
+  void shouldProjectSlicedResultsIntoDto() {
+    Slice<NameOnlyRecord> slice =
+        repository
+            .query()
+            .where("status", Operators.IS_NOT_NULL, null)
+            .sort(Sort.by("name"))
+            .select("name")
+            .selectInto(NameOnlyRecord.class)
+            .findSlice(PageRequest.of(0, 2));
+
+    assertThat(slice.getContent())
+        .containsExactly(new NameOnlyRecord("Borja"), new NameOnlyRecord("John"));
+    assertThat(slice.hasNext()).isTrue();
+  }
+
+  @Test
+  void shouldSliceProjectedResults() {
+    Slice<?> slice =
+        repository
+            .query()
+            .where("status", Operators.IS_NOT_NULL, null)
+            .sort(Sort.by("name"))
+            .select("name")
+            .findSlice(PageRequest.of(0, 2));
+
+    assertThat(slice.getContent()).extracting(Object::toString).containsExactly("Borja", "John");
+    assertThat(slice.hasNext()).isTrue();
+  }
+
+  @Test
+  void shouldSliceGroupedAggregateResults() {
+    Slice<?> slice =
+        repository
+            .query()
+            .where("status", Operators.IS_NOT_NULL, null)
+            .groupBy("status")
+            .sort(Sort.by("status"))
+            .select("status")
+            .count("id")
+            .findSlice(PageRequest.of(0, 1));
+
+    assertThat(slice.getContent()).hasSize(1);
+    assertThat(slice.hasNext()).isTrue();
   }
 
   // -- includeNulls --
@@ -703,6 +808,26 @@ class SpecificationRepositoryIntegrationTest {
         .extracting(Object::toString)
         .containsExactly("NameOnlyRecord[name=Anna]", "NameOnlyRecord[name=Borja]");
     assertThat(page.getTotalElements()).isEqualTo(4);
+  }
+
+  @Test
+  @SuppressWarnings({"rawtypes", "unchecked"})
+  void shouldFindSliceWithProjectedQueryPlanMetadata() {
+    QueryPlan<TestCustomer> plan =
+        repository
+            .query()
+            .where("status", Operators.IS_NOT_NULL, null)
+            .sort(Sort.by("name"))
+            .select("name")
+            .selectInto(NameOnlyRecord.class)
+            .plan();
+
+    Slice<?> slice = repository.findSlice((QueryPlan) plan, PageRequest.of(0, 2));
+
+    assertThat(slice.getContent())
+        .extracting(Object::toString)
+        .containsExactly("NameOnlyRecord[name=Borja]", "NameOnlyRecord[name=John]");
+    assertThat(slice.hasNext()).isTrue();
   }
 
   @Test


### PR DESCRIPTION
Closes #24.

## Summary

- Adds `findSlice(Pageable)` to the fluent query, returning Spring Data's `Slice<T>` via the standard "fetch `pageSize + 1` rows" technique — one SQL query, no `COUNT(*)`.
- Adds `findSlice(QueryPlan, Pageable)` and a default `findSliceProjected` to `SpecificationRepository`, plus the matching terminal on `ProjectedSpecificationExecutableQuery`.
- Refactors `SpecificationRepositoryImpl` so the entity `findAll(Pageable)` and `findSlice` paths share a single `fetchEntityPage` helper. Sort priority (pageable sort over plan sort), projection routing and groupBy handling are reused.
- Documents `Page` vs `Slice` and a keyset pagination design note (deferred to a follow-up issue) in `docs/pagination.md`, with a short pointer from the README pagination section.

## Why Slice

`findAll(Pageable)` always issues a second `COUNT(*)` query. For large filtered tables that count is the dominant cost, and callers that only need "is there a next page" can skip it. `Slice` matches the Spring Data contract callers already know.

## Why keyset is deferred

Keyset pagination needs more than a Slice constructor: a stable total ordering, an opaque cursor token format, a DSL surface to pass the cursor through, and operator support for `(col1, col2, ...) > (val1, val2, ...)` row constructors with mixed asc/desc. That is a separate, larger change. The doc captures the proposed shape and the open design questions so a follow-up PR can pick it up.

## Test plan

- [x] `./gradlew quality` (all modules + 100% JaCoCo coverage gate) — green locally
- [x] New integration tests cover entity, projected (`select` + `selectInto`), DTO record, grouped-aggregate and empty-result Slice paths, plus pageable-sort-overrides-plan-sort
- [x] New integration test calls `repository.findSlice(plan, pageable)` directly with a projection-bearing plan to cover the `projectionType != null` branch
- [x] New unit test asserts the default `findSliceProjected` throws `UnsupportedOperationException` for repositories that opt out of projections
- [ ] Smoke check via a demo controller (not done — no behavioral change to existing endpoints; new terminal is additive)