### PR TITLE
feat: add HAVING and structured grouped results (#25)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Extensible Spring Data JPA query library with a fluent DSL and native-friendly a
 
 - Fluent query DSL for chained `where`, `and`, `or`, `join`, and `fetch` operations
 - Correlated subqueries: `exists` / `notExists` (association or entity-based) and `inSubquery` / `notInSubquery`
-- Aggregate projections with `sum`, `avg`, `min`, `max`, and `count(field)`
+- Aggregate projections with `sum`, `avg`, `min`, `max`, and `count(field)`, plus aliasing, `having(...)` and structured `GroupedRow` results (see [docs/reporting.md](docs/reporting.md))
 - Pure builder model -- the builder only creates an immutable query plan
 - `SpecificationRepository` as a repository base abstraction for execution
 - Per-query field whitelisting for secure API exposure (`AllowedFieldsPolicy`)
@@ -176,6 +176,10 @@ Notes:
 - grouped aggregate queries return one row per group
 - `count(field)` counts non-null values for the selected field
 - `sum(...)` and `avg(...)` require numeric fields
+- aggregates can be aliased (`sumAs("revenue", "amount")`) and filtered with `having(...)`
+- `findAllGrouped()` returns a list of `GroupedRow`, supporting lookup by alias or column name
+
+See [docs/reporting.md](docs/reporting.md) for the full reporting and analytical query reference.
 
 ## Usage Examples
 

--- a/docs/reporting.md
+++ b/docs/reporting.md
@@ -1,0 +1,138 @@
+# Reporting and analytical queries
+
+This guide covers the reporting-oriented features of the query DSL: aliased
+aggregate selections, the `having` clause for filtering grouped results, and
+the `GroupedRow` value object for column lookup by alias.
+
+These features build on top of `groupBy(...)` and the existing aggregate
+functions (`sum`, `avg`, `min`, `max`, `count`). They require no extra
+configuration: any `SpecificationRepository` exposes them through the same
+fluent query builder.
+
+## Multiple aggregates in a single query
+
+Several aggregate selections can be combined in the same query. This was
+already supported through the projection pipeline; the new aliasing API makes
+the result columns easier to refer to from `having` and `findAllGrouped()`.
+
+```java
+List<GroupedRow> rows = customerRepository.query()
+    .where("status", Operators.IS_NOT_NULL, null)
+    .groupBy("status")
+    .sort(Sort.by("status"))
+    .select("status")
+    .sumAs("totalAge", "age")
+    .avgAs("averageAge", "age")
+    .countAs("customers", "id")
+    .minAs("youngest", "age")
+    .maxAs("oldest", "age")
+    .findAllGrouped();
+```
+
+The aliased variants (`sumAs`, `avgAs`, `minAs`, `maxAs`, `countAs`) take an
+explicit alias plus the field. The original `sum`, `avg`, `min`, `max`,
+`count` overloads still work without an alias; the column name is then
+derived as `FUNCTION_field` (for example `SUM_age`).
+
+For full control, use `aggregate(AggregateFunction.SUM, "age", "totalAge")`.
+
+## `findAllGrouped()` and `GroupedRow`
+
+`findAllGrouped()` is a terminal method that returns each result row as a
+`GroupedRow`. A `GroupedRow` carries both the column names (from the
+selections) and their values, and supports lookup by index or by name:
+
+```java
+GroupedRow active = rows.get(0);
+String status      = (String) active.get("status");
+Number totalAge    = (Number) active.get("totalAge");
+Number averageAge  = (Number) active.get("averageAge");
+Long   customers   = (Long)   active.get("customers");
+```
+
+Notes:
+
+- Column order matches the order in which selections were declared.
+- For `FieldSelection` (`select(...)`) the column name is the field name.
+- For `AggregateSelection` the column name is the alias if provided, or
+  `FUNCTION_field` (for example `COUNT_id`) otherwise.
+- `GroupedRow.values()` returns a defensive copy of the underlying array.
+- Calling `findAllGrouped()` on a query without any selection throws
+  `IllegalStateException` -- there is nothing meaningful to project.
+
+If you prefer constructor-based DTOs, the existing `selectInto(MyRecord.class)`
+projection still works and is often a better fit when columns are known at
+compile time.
+
+## `having` clause
+
+`having(function, field, operator, value)` filters grouped rows after
+aggregation. It is the analytical counterpart of `where(...)`: `where`
+runs before `groupBy`, `having` runs after. Multiple `having(...)` calls
+on the same query are combined with logical AND -- nested groups are not
+supported (yet).
+
+```java
+List<GroupedRow> bigSpenders = orderRepository.query()
+    .groupBy("customerId")
+    .sumAs("revenue", "amount")
+    .countAs("orders", "id")
+    .having(AggregateFunction.SUM, "amount", Operators.GREATER_THAN, 1_000)
+    .having(AggregateFunction.COUNT, "id", Operators.GREATER_THAN_OR_EQUAL, 5)
+    .findAllGrouped();
+```
+
+### Supported operators
+
+The HAVING clause supports the comparison operators that map cleanly onto
+aggregate expressions:
+
+| Operator | Notes |
+|---|---|
+| `Operators.EQUALS` / `NOT_EQUALS` | Equality and inequality. |
+| `Operators.GREATER_THAN` / `GREATER_THAN_OR_EQUAL` | Numeric / comparable comparisons. |
+| `Operators.LESS_THAN` / `LESS_THAN_OR_EQUAL` | Numeric / comparable comparisons. |
+| `Operators.BETWEEN` | Value must be a 2-element `Iterable` (lower, upper). |
+| `Operators.IS_NULL` / `IS_NOT_NULL` | Useful when an aggregate may be `NULL`. |
+
+Pattern operators (`LIKE`, `CONTAINS`, ...) and the collection operators
+(`IN`, `IS_EMPTY`, ...) are not allowed in the `having` clause and result in
+`IllegalArgumentException` at execution time. The same exception is raised
+for any custom or unrecognized operator.
+
+### Validation
+
+Calling `having(...)` without a preceding `groupBy(...)` is rejected by the
+builder with `IllegalStateException("having requires at least one groupBy field")`.
+This mirrors SQL semantics and catches misuse early.
+
+When an `AllowedFieldsPolicy` is attached to the query, the field referenced
+by every `having(...)` clause is validated against the *filterable* fields
+set, exactly like `where(...)` clauses. Use this to expose `having` to
+external API callers safely.
+
+## Putting it together
+
+```java
+AllowedFieldsPolicy policy = AllowedFieldsPolicy.of(
+    Set.of("status", "amount", "id"),
+    Set.of("status"));
+
+List<GroupedRow> rows = orderRepository.query()
+    .allowedFields(policy)
+    .where("status", Operators.IS_NOT_NULL, null)
+    .groupBy("status")
+    .sort(Sort.by("status"))
+    .select("status")
+    .sumAs("revenue", "amount")
+    .countAs("orders", "id")
+    .having(AggregateFunction.SUM, "amount", Operators.GREATER_THAN, 100)
+    .findAllGrouped();
+
+for (GroupedRow row : rows) {
+    System.out.println(
+        row.get("status") + " -> "
+        + row.get("revenue") + " across "
+        + row.get("orders") + " orders");
+}
+```

--- a/examples/boot3-demo/src/main/java/com/borjaglez/specrepository/examples/boot3/controller/ProductController.java
+++ b/examples/boot3-demo/src/main/java/com/borjaglez/specrepository/examples/boot3/controller/ProductController.java
@@ -1,5 +1,6 @@
 package com.borjaglez.specrepository.examples.boot3.controller;
 
+import java.math.BigDecimal;
 import java.util.List;
 
 import org.springframework.data.domain.Page;
@@ -7,6 +8,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import com.borjaglez.specrepository.core.GroupedRow;
 import com.borjaglez.specrepository.core.QueryPlan;
 import com.borjaglez.specrepository.examples.boot3.entity.Product;
 import com.borjaglez.specrepository.examples.boot3.service.ProductAggregateSummaryResponse;
@@ -129,6 +131,11 @@ public class ProductController {
   @GetMapping("/count/grouped-by-category")
   public long countGroupedByCategory() {
     return productService.countGroupedByCategory();
+  }
+
+  @GetMapping("/reporting/status-revenue-above")
+  public List<GroupedRow> findStatusRevenueAbove(@RequestParam("threshold") BigDecimal threshold) {
+    return productService.findStatusRevenueAbove(threshold);
   }
 
   @GetMapping("/filter")

--- a/examples/boot3-demo/src/main/java/com/borjaglez/specrepository/examples/boot3/service/ProductService.java
+++ b/examples/boot3-demo/src/main/java/com/borjaglez/specrepository/examples/boot3/service/ProductService.java
@@ -11,6 +11,8 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.borjaglez.specrepository.core.AggregateFunction;
+import com.borjaglez.specrepository.core.GroupedRow;
 import com.borjaglez.specrepository.core.Operators;
 import com.borjaglez.specrepository.core.QueryPlan;
 import com.borjaglez.specrepository.examples.boot3.entity.Product;
@@ -218,6 +220,24 @@ public class ProductService {
   /** Grouped count: number of distinct categories with products. */
   public long countGroupedByCategory() {
     return productRepository.query().groupBy("category.name").count();
+  }
+
+  /**
+   * Reporting demo: aggregate per status with HAVING and structured GroupedRow output. Returns
+   * statuses whose total price exceeds the supplied threshold, along with their order count and
+   * aggregated revenue, ordered by status.
+   */
+  public List<GroupedRow> findStatusRevenueAbove(BigDecimal threshold) {
+    return productRepository
+        .query()
+        .where("status", Operators.IS_NOT_NULL, null)
+        .groupBy("status")
+        .sort(Sort.by("status"))
+        .select("status")
+        .sumAs("revenue", "price")
+        .countAs("items", "id")
+        .having(AggregateFunction.SUM, "price", Operators.GREATER_THAN, threshold)
+        .findAllGrouped();
   }
 
   /** Execute a pre-built QueryPlan from HTTP filter parsing. */

--- a/specification-repository-core/src/main/java/com/borjaglez/specrepository/core/AggregateSelection.java
+++ b/specification-repository-core/src/main/java/com/borjaglez/specrepository/core/AggregateSelection.java
@@ -2,9 +2,21 @@ package com.borjaglez.specrepository.core;
 
 import java.util.Objects;
 
-public record AggregateSelection(AggregateFunction function, String field) implements Selection {
+public record AggregateSelection(AggregateFunction function, String field, String alias)
+    implements Selection {
   public AggregateSelection {
     Objects.requireNonNull(function, "function must not be null");
     Objects.requireNonNull(field, "field must not be null");
+    if (alias != null && alias.isBlank()) {
+      throw new IllegalArgumentException("alias must not be blank");
+    }
+  }
+
+  public AggregateSelection(AggregateFunction function, String field) {
+    this(function, field, null);
+  }
+
+  public String columnName() {
+    return alias != null ? alias : function.name() + "_" + field;
   }
 }

--- a/specification-repository-core/src/main/java/com/borjaglez/specrepository/core/GroupedRow.java
+++ b/specification-repository-core/src/main/java/com/borjaglez/specrepository/core/GroupedRow.java
@@ -1,0 +1,73 @@
+package com.borjaglez.specrepository.core;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+
+public final class GroupedRow {
+  private final List<String> columns;
+  private final Object[] values;
+
+  public GroupedRow(List<String> columns, Object[] values) {
+    Objects.requireNonNull(columns, "columns must not be null");
+    Objects.requireNonNull(values, "values must not be null");
+    if (columns.size() != values.length) {
+      throw new IllegalArgumentException(
+          "columns and values must have the same size: " + columns.size() + " != " + values.length);
+    }
+    this.columns = List.copyOf(columns);
+    this.values = values.clone();
+  }
+
+  public List<String> columns() {
+    return columns;
+  }
+
+  public Object[] values() {
+    return values.clone();
+  }
+
+  public Object get(int index) {
+    if (index < 0 || index >= values.length) {
+      throw new IndexOutOfBoundsException("index out of bounds: " + index);
+    }
+    return values[index];
+  }
+
+  public Object get(String column) {
+    Objects.requireNonNull(column, "column must not be null");
+    int index = columns.indexOf(column);
+    if (index < 0) {
+      throw new IllegalArgumentException("unknown column: " + column);
+    }
+    return values[index];
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (this == other) {
+      return true;
+    }
+    if (!(other instanceof GroupedRow row)) {
+      return false;
+    }
+    return columns.equals(row.columns) && Arrays.equals(values, row.values);
+  }
+
+  @Override
+  public int hashCode() {
+    return 31 * columns.hashCode() + Arrays.hashCode(values);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder("GroupedRow{");
+    for (int i = 0; i < columns.size(); i++) {
+      if (i > 0) {
+        sb.append(", ");
+      }
+      sb.append(columns.get(i)).append('=').append(values[i]);
+    }
+    return sb.append('}').toString();
+  }
+}

--- a/specification-repository-core/src/main/java/com/borjaglez/specrepository/core/HavingCondition.java
+++ b/specification-repository-core/src/main/java/com/borjaglez/specrepository/core/HavingCondition.java
@@ -1,0 +1,12 @@
+package com.borjaglez.specrepository.core;
+
+import java.util.Objects;
+
+public record HavingCondition(
+    AggregateFunction function, String field, FilterOperator operator, Object value) {
+  public HavingCondition {
+    Objects.requireNonNull(function, "function must not be null");
+    Objects.requireNonNull(field, "field must not be null");
+    Objects.requireNonNull(operator, "operator must not be null");
+  }
+}

--- a/specification-repository-core/src/main/java/com/borjaglez/specrepository/core/QueryPlan.java
+++ b/specification-repository-core/src/main/java/com/borjaglez/specrepository/core/QueryPlan.java
@@ -14,11 +14,13 @@ public record QueryPlan<T>(
     List<Selection> selections,
     Class<?> projectionType,
     List<String> groupBy,
+    List<HavingCondition> having,
     Sort sort,
     boolean distinct,
     AllowedFieldsPolicy allowedFieldsPolicy) {
 
   public QueryPlan {
+    Objects.requireNonNull(having, "having must not be null");
     Objects.requireNonNull(allowedFieldsPolicy, "allowedFieldsPolicy must not be null");
   }
 
@@ -42,9 +44,37 @@ public record QueryPlan<T>(
         selections,
         projectionType,
         groupBy,
+        List.of(),
         sort,
         distinct,
         AllowedFieldsPolicy.allowAll());
+  }
+
+  public QueryPlan(
+      Class<T> entityType,
+      GroupCondition rootCondition,
+      List<JoinInstruction> joins,
+      List<FetchInstruction> fetches,
+      List<String> projections,
+      List<Selection> selections,
+      Class<?> projectionType,
+      List<String> groupBy,
+      Sort sort,
+      boolean distinct,
+      AllowedFieldsPolicy allowedFieldsPolicy) {
+    this(
+        entityType,
+        rootCondition,
+        joins,
+        fetches,
+        projections,
+        selections,
+        projectionType,
+        groupBy,
+        List.of(),
+        sort,
+        distinct,
+        allowedFieldsPolicy);
   }
 
   public boolean hasSelections() {

--- a/specification-repository-core/src/main/java/com/borjaglez/specrepository/core/QueryPlanBuilder.java
+++ b/specification-repository-core/src/main/java/com/borjaglez/specrepository/core/QueryPlanBuilder.java
@@ -17,6 +17,7 @@ public class QueryPlanBuilder<T> {
   private final List<String> projections = new ArrayList<>();
   private final List<Selection> selections = new ArrayList<>();
   private final List<String> groupBy = new ArrayList<>();
+  private final List<HavingCondition> having = new ArrayList<>();
   private Sort sort = Sort.unsorted();
   private Class<?> projectionType;
   private boolean distinct;
@@ -125,32 +126,58 @@ public class QueryPlanBuilder<T> {
   }
 
   public QueryPlanBuilder<T> sum(String field) {
-    selections.add(new AggregateSelection(AggregateFunction.SUM, field));
-    return this;
+    return aggregate(AggregateFunction.SUM, field, null);
+  }
+
+  public QueryPlanBuilder<T> sumAs(String alias, String field) {
+    return aggregate(AggregateFunction.SUM, field, alias);
   }
 
   public QueryPlanBuilder<T> avg(String field) {
-    selections.add(new AggregateSelection(AggregateFunction.AVG, field));
-    return this;
+    return aggregate(AggregateFunction.AVG, field, null);
+  }
+
+  public QueryPlanBuilder<T> avgAs(String alias, String field) {
+    return aggregate(AggregateFunction.AVG, field, alias);
   }
 
   public QueryPlanBuilder<T> min(String field) {
-    selections.add(new AggregateSelection(AggregateFunction.MIN, field));
-    return this;
+    return aggregate(AggregateFunction.MIN, field, null);
+  }
+
+  public QueryPlanBuilder<T> minAs(String alias, String field) {
+    return aggregate(AggregateFunction.MIN, field, alias);
   }
 
   public QueryPlanBuilder<T> max(String field) {
-    selections.add(new AggregateSelection(AggregateFunction.MAX, field));
-    return this;
+    return aggregate(AggregateFunction.MAX, field, null);
+  }
+
+  public QueryPlanBuilder<T> maxAs(String alias, String field) {
+    return aggregate(AggregateFunction.MAX, field, alias);
   }
 
   public QueryPlanBuilder<T> count(String field) {
-    selections.add(new AggregateSelection(AggregateFunction.COUNT, field));
+    return aggregate(AggregateFunction.COUNT, field, null);
+  }
+
+  public QueryPlanBuilder<T> countAs(String alias, String field) {
+    return aggregate(AggregateFunction.COUNT, field, alias);
+  }
+
+  public QueryPlanBuilder<T> aggregate(AggregateFunction function, String field, String alias) {
+    selections.add(new AggregateSelection(function, field, alias));
     return this;
   }
 
   public QueryPlanBuilder<T> groupBy(String... fields) {
     groupBy.addAll(Arrays.asList(fields));
+    return this;
+  }
+
+  public QueryPlanBuilder<T> having(
+      AggregateFunction function, String field, FilterOperator operator, Object value) {
+    having.add(new HavingCondition(function, field, operator, value));
     return this;
   }
 
@@ -170,6 +197,9 @@ public class QueryPlanBuilder<T> {
   }
 
   public QueryPlan<T> build() {
+    if (!having.isEmpty() && groupBy.isEmpty()) {
+      throw new IllegalStateException("having requires at least one groupBy field");
+    }
     return new QueryPlan<>(
         entityType,
         rootGroup.build(),
@@ -179,6 +209,7 @@ public class QueryPlanBuilder<T> {
         List.copyOf(selections),
         projectionType,
         List.copyOf(groupBy),
+        List.copyOf(having),
         sort,
         distinct,
         allowedFieldsPolicy);

--- a/specification-repository-core/src/test/java/com/borjaglez/specrepository/core/AggregateSelectionTest.java
+++ b/specification-repository-core/src/test/java/com/borjaglez/specrepository/core/AggregateSelectionTest.java
@@ -1,0 +1,46 @@
+package com.borjaglez.specrepository.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+
+import org.junit.jupiter.api.Test;
+
+class AggregateSelectionTest {
+
+  @Test
+  void shouldDefaultAliasToNullWhenLegacyConstructorUsed() {
+    AggregateSelection selection = new AggregateSelection(AggregateFunction.SUM, "amount");
+    assertThat(selection.alias()).isNull();
+    assertThat(selection.columnName()).isEqualTo("SUM_amount");
+  }
+
+  @Test
+  void shouldUseAliasAsColumnNameWhenProvided() {
+    AggregateSelection selection =
+        new AggregateSelection(AggregateFunction.AVG, "score", "averageScore");
+    assertThat(selection.alias()).isEqualTo("averageScore");
+    assertThat(selection.columnName()).isEqualTo("averageScore");
+  }
+
+  @Test
+  void shouldRejectNullFunction() {
+    assertThatNullPointerException()
+        .isThrownBy(() -> new AggregateSelection(null, "field"))
+        .withMessage("function must not be null");
+  }
+
+  @Test
+  void shouldRejectNullField() {
+    assertThatNullPointerException()
+        .isThrownBy(() -> new AggregateSelection(AggregateFunction.SUM, null))
+        .withMessage("field must not be null");
+  }
+
+  @Test
+  void shouldRejectBlankAlias() {
+    assertThatIllegalArgumentException()
+        .isThrownBy(() -> new AggregateSelection(AggregateFunction.SUM, "amount", "  "))
+        .withMessage("alias must not be blank");
+  }
+}

--- a/specification-repository-core/src/test/java/com/borjaglez/specrepository/core/GroupedRowTest.java
+++ b/specification-repository-core/src/test/java/com/borjaglez/specrepository/core/GroupedRowTest.java
@@ -1,0 +1,107 @@
+package com.borjaglez.specrepository.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+class GroupedRowTest {
+
+  @Test
+  void shouldExposeColumnsAndValues() {
+    GroupedRow row = new GroupedRow(List.of("status", "total"), new Object[] {"ACTIVE", 42L});
+    assertThat(row.columns()).containsExactly("status", "total");
+    assertThat(row.values()).containsExactly("ACTIVE", 42L);
+  }
+
+  @Test
+  void shouldLookupByIndex() {
+    GroupedRow row = new GroupedRow(List.of("a", "b"), new Object[] {1, 2});
+    assertThat(row.get(0)).isEqualTo(1);
+    assertThat(row.get(1)).isEqualTo(2);
+  }
+
+  @Test
+  void shouldLookupByColumnName() {
+    GroupedRow row = new GroupedRow(List.of("status", "total"), new Object[] {"X", 7L});
+    assertThat(row.get("status")).isEqualTo("X");
+    assertThat(row.get("total")).isEqualTo(7L);
+  }
+
+  @Test
+  void shouldRejectUnknownColumn() {
+    GroupedRow row = new GroupedRow(List.of("a"), new Object[] {1});
+    assertThatIllegalArgumentException()
+        .isThrownBy(() -> row.get("missing"))
+        .withMessage("unknown column: missing");
+  }
+
+  @Test
+  void shouldRejectNullColumnLookup() {
+    GroupedRow row = new GroupedRow(List.of("a"), new Object[] {1});
+    assertThatNullPointerException().isThrownBy(() -> row.get((String) null));
+  }
+
+  @Test
+  void shouldRejectIndexOutOfBounds() {
+    GroupedRow row = new GroupedRow(List.of("a"), new Object[] {1});
+    assertThatThrownBy(() -> row.get(2)).isInstanceOf(IndexOutOfBoundsException.class);
+    assertThatThrownBy(() -> row.get(-1)).isInstanceOf(IndexOutOfBoundsException.class);
+  }
+
+  @Test
+  void shouldRejectMismatchedSizes() {
+    assertThatIllegalArgumentException()
+        .isThrownBy(() -> new GroupedRow(List.of("a", "b"), new Object[] {1}))
+        .withMessageContaining("columns and values must have the same size");
+  }
+
+  @Test
+  void shouldRejectNullColumns() {
+    assertThatNullPointerException()
+        .isThrownBy(() -> new GroupedRow(null, new Object[] {1}))
+        .withMessage("columns must not be null");
+  }
+
+  @Test
+  void shouldRejectNullValues() {
+    assertThatNullPointerException()
+        .isThrownBy(() -> new GroupedRow(List.of("a"), null))
+        .withMessage("values must not be null");
+  }
+
+  @Test
+  void valuesShouldBeDefensiveCopy() {
+    Object[] source = new Object[] {1, 2};
+    GroupedRow row = new GroupedRow(List.of("a", "b"), source);
+    source[0] = 99;
+    assertThat(row.get(0)).isEqualTo(1);
+    Object[] returned = row.values();
+    returned[1] = 99;
+    assertThat(row.get(1)).isEqualTo(2);
+  }
+
+  @Test
+  void equalsAndHashCodeShouldRespectContent() {
+    GroupedRow a = new GroupedRow(List.of("c"), new Object[] {1});
+    GroupedRow b = new GroupedRow(List.of("c"), new Object[] {1});
+    GroupedRow differentValue = new GroupedRow(List.of("c"), new Object[] {2});
+    GroupedRow differentColumns = new GroupedRow(List.of("d"), new Object[] {1});
+    assertThat(a).isEqualTo(a);
+    assertThat(a).isEqualTo(b).hasSameHashCodeAs(b);
+    assertThat(a).isNotEqualTo(differentValue);
+    assertThat(a).isNotEqualTo(differentColumns);
+    assertThat(a).isNotEqualTo("not a row");
+    assertThat(a).isNotEqualTo(null);
+  }
+
+  @Test
+  void toStringShouldIncludeColumnsAndValues() {
+    GroupedRow row = new GroupedRow(List.of("status", "total"), new Object[] {"X", 7L});
+    assertThat(row.toString()).isEqualTo("GroupedRow{status=X, total=7}");
+  }
+}

--- a/specification-repository-core/src/test/java/com/borjaglez/specrepository/core/HavingConditionTest.java
+++ b/specification-repository-core/src/test/java/com/borjaglez/specrepository/core/HavingConditionTest.java
@@ -1,0 +1,47 @@
+package com.borjaglez.specrepository.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+
+import org.junit.jupiter.api.Test;
+
+class HavingConditionTest {
+
+  @Test
+  void shouldExposeAllComponents() {
+    HavingCondition condition =
+        new HavingCondition(AggregateFunction.SUM, "amount", Operators.GREATER_THAN, 100);
+    assertThat(condition.function()).isEqualTo(AggregateFunction.SUM);
+    assertThat(condition.field()).isEqualTo("amount");
+    assertThat(condition.operator()).isEqualTo(Operators.GREATER_THAN);
+    assertThat(condition.value()).isEqualTo(100);
+  }
+
+  @Test
+  void shouldRejectNullFunction() {
+    assertThatNullPointerException()
+        .isThrownBy(() -> new HavingCondition(null, "amount", Operators.EQUALS, 1))
+        .withMessage("function must not be null");
+  }
+
+  @Test
+  void shouldRejectNullField() {
+    assertThatNullPointerException()
+        .isThrownBy(() -> new HavingCondition(AggregateFunction.SUM, null, Operators.EQUALS, 1))
+        .withMessage("field must not be null");
+  }
+
+  @Test
+  void shouldRejectNullOperator() {
+    assertThatNullPointerException()
+        .isThrownBy(() -> new HavingCondition(AggregateFunction.SUM, "amount", null, 1))
+        .withMessage("operator must not be null");
+  }
+
+  @Test
+  void shouldAllowNullValueForUnaryOperators() {
+    HavingCondition condition =
+        new HavingCondition(AggregateFunction.SUM, "amount", Operators.IS_NULL, null);
+    assertThat(condition.value()).isNull();
+  }
+}

--- a/specification-repository-core/src/test/java/com/borjaglez/specrepository/core/QueryPlanBuilderTest.java
+++ b/specification-repository-core/src/test/java/com/borjaglez/specrepository/core/QueryPlanBuilderTest.java
@@ -285,6 +285,99 @@ class QueryPlanBuilderTest {
             SubqueryKind.NOT_IN);
   }
 
+  @Test
+  void shouldBuildAggregateWithAlias() {
+    QueryPlan<String> plan =
+        new QueryPlanBuilder<>(String.class)
+            .groupBy("status")
+            .sumAs("total", "amount")
+            .avgAs("avgScore", "score")
+            .minAs("minDate", "createdAt")
+            .maxAs("maxDate", "updatedAt")
+            .countAs("items", "id")
+            .aggregate(AggregateFunction.SUM, "extra", "extraTotal")
+            .build();
+
+    assertThat(plan.selections())
+        .containsExactly(
+            new AggregateSelection(AggregateFunction.SUM, "amount", "total"),
+            new AggregateSelection(AggregateFunction.AVG, "score", "avgScore"),
+            new AggregateSelection(AggregateFunction.MIN, "createdAt", "minDate"),
+            new AggregateSelection(AggregateFunction.MAX, "updatedAt", "maxDate"),
+            new AggregateSelection(AggregateFunction.COUNT, "id", "items"),
+            new AggregateSelection(AggregateFunction.SUM, "extra", "extraTotal"));
+  }
+
+  @Test
+  void shouldStoreHavingConditionsInBuildOrder() {
+    QueryPlan<String> plan =
+        new QueryPlanBuilder<>(String.class)
+            .groupBy("status")
+            .sum("amount")
+            .having(AggregateFunction.SUM, "amount", Operators.GREATER_THAN, 100)
+            .having(AggregateFunction.COUNT, "id", Operators.LESS_THAN, 10)
+            .build();
+
+    assertThat(plan.having())
+        .containsExactly(
+            new HavingCondition(AggregateFunction.SUM, "amount", Operators.GREATER_THAN, 100),
+            new HavingCondition(AggregateFunction.COUNT, "id", Operators.LESS_THAN, 10));
+  }
+
+  @Test
+  void shouldRejectHavingWithoutGroupBy() {
+    assertThatIllegalStateException()
+        .isThrownBy(
+            () ->
+                new QueryPlanBuilder<>(String.class)
+                    .sum("amount")
+                    .having(AggregateFunction.SUM, "amount", Operators.GREATER_THAN, 1)
+                    .build())
+        .withMessage("having requires at least one groupBy field");
+  }
+
+  @Test
+  void queryPlanLegacyConstructorWithPolicyShouldDefaultHavingToEmpty() {
+    AllowedFieldsPolicy policy =
+        AllowedFieldsPolicy.of(java.util.Set.of("name"), java.util.Set.of("name"));
+    QueryPlan<String> plan =
+        new QueryPlan<>(
+            String.class,
+            new GroupCondition(LogicalOperator.AND, java.util.List.of()),
+            java.util.List.of(),
+            java.util.List.of(),
+            java.util.List.of(),
+            java.util.List.of(),
+            null,
+            java.util.List.of(),
+            Sort.unsorted(),
+            false,
+            policy);
+    assertThat(plan.having()).isEmpty();
+    assertThat(plan.allowedFieldsPolicy()).isSameAs(policy);
+  }
+
+  @Test
+  void queryPlanShouldRejectNullHaving() {
+    assertThatNullPointerException()
+        .isThrownBy(
+            () ->
+                new QueryPlan<>(
+                    String.class,
+                    new GroupCondition(LogicalOperator.AND, java.util.List.of()),
+                    java.util.List.of(),
+                    java.util.List.of(),
+                    java.util.List.of(),
+                    java.util.List.of(),
+                    null,
+                    java.util.List.of(),
+                    null,
+                    Sort.unsorted(),
+                    false,
+                    AllowedFieldsPolicy.allowAll()))
+        .withMessage("having must not be null");
+  }
+
   private record NameEmailProjection(String name, String email) {}
 
   private record CountProjection(Long count) {}

--- a/specification-repository-jpa/src/main/java/com/borjaglez/specrepository/jpa/SpecificationExecutableQuery.java
+++ b/specification-repository-jpa/src/main/java/com/borjaglez/specrepository/jpa/SpecificationExecutableQuery.java
@@ -9,9 +9,11 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
 
+import com.borjaglez.specrepository.core.AggregateFunction;
 import com.borjaglez.specrepository.core.AllowedFieldsPolicy;
 import com.borjaglez.specrepository.core.ConditionGroupBuilder;
 import com.borjaglez.specrepository.core.FilterOperator;
+import com.borjaglez.specrepository.core.GroupedRow;
 import com.borjaglez.specrepository.core.QueryPlan;
 import com.borjaglez.specrepository.core.QueryPlanBuilder;
 import com.borjaglez.specrepository.core.SubqueryBuilder;
@@ -182,6 +184,50 @@ public class SpecificationExecutableQuery<T> extends QueryPlanBuilder<T> {
   }
 
   @Override
+  public SpecificationExecutableQuery<T> sumAs(String alias, String field) {
+    super.sumAs(alias, field);
+    return this;
+  }
+
+  @Override
+  public SpecificationExecutableQuery<T> avgAs(String alias, String field) {
+    super.avgAs(alias, field);
+    return this;
+  }
+
+  @Override
+  public SpecificationExecutableQuery<T> minAs(String alias, String field) {
+    super.minAs(alias, field);
+    return this;
+  }
+
+  @Override
+  public SpecificationExecutableQuery<T> maxAs(String alias, String field) {
+    super.maxAs(alias, field);
+    return this;
+  }
+
+  @Override
+  public SpecificationExecutableQuery<T> countAs(String alias, String field) {
+    super.countAs(alias, field);
+    return this;
+  }
+
+  @Override
+  public SpecificationExecutableQuery<T> aggregate(
+      AggregateFunction function, String field, String alias) {
+    super.aggregate(function, field, alias);
+    return this;
+  }
+
+  @Override
+  public SpecificationExecutableQuery<T> having(
+      AggregateFunction function, String field, FilterOperator operator, Object value) {
+    super.having(function, field, operator, value);
+    return this;
+  }
+
+  @Override
   public SpecificationExecutableQuery<T> sort(Sort sort) {
     super.sort(sort);
     return this;
@@ -207,6 +253,10 @@ public class SpecificationExecutableQuery<T> extends QueryPlanBuilder<T> {
 
   public List<T> findAll() {
     return repository.findAll(build());
+  }
+
+  public List<GroupedRow> findAllGrouped() {
+    return repository.findAllGrouped(build());
   }
 
   public Page<T> findAll(Pageable pageable) {

--- a/specification-repository-jpa/src/main/java/com/borjaglez/specrepository/jpa/SpecificationRepository.java
+++ b/specification-repository-jpa/src/main/java/com/borjaglez/specrepository/jpa/SpecificationRepository.java
@@ -10,6 +10,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.repository.NoRepositoryBean;
 
+import com.borjaglez.specrepository.core.GroupedRow;
 import com.borjaglez.specrepository.core.QueryPlan;
 
 @NoRepositoryBean
@@ -46,4 +47,8 @@ public interface SpecificationRepository<T, ID>
   }
 
   long count(QueryPlan<T> plan);
+
+  default List<GroupedRow> findAllGrouped(QueryPlan<T> plan) {
+    throw new UnsupportedOperationException("Grouped queries are not supported by this repository");
+  }
 }

--- a/specification-repository-jpa/src/main/java/com/borjaglez/specrepository/jpa/SpecificationRepositoryImpl.java
+++ b/specification-repository-jpa/src/main/java/com/borjaglez/specrepository/jpa/SpecificationRepositoryImpl.java
@@ -10,7 +10,6 @@ import jakarta.persistence.EntityManager;
 import jakarta.persistence.TypedQuery;
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.CriteriaQuery;
-import jakarta.persistence.criteria.Expression;
 import jakarta.persistence.criteria.Path;
 import jakarta.persistence.criteria.Root;
 import jakarta.persistence.criteria.Selection;
@@ -26,8 +25,10 @@ import org.springframework.data.jpa.repository.support.SimpleJpaRepository;
 
 import com.borjaglez.specrepository.core.AggregateSelection;
 import com.borjaglez.specrepository.core.FieldSelection;
+import com.borjaglez.specrepository.core.GroupedRow;
 import com.borjaglez.specrepository.core.JoinMode;
 import com.borjaglez.specrepository.core.QueryPlan;
+import com.borjaglez.specrepository.jpa.support.AggregateExpressionFactory;
 import com.borjaglez.specrepository.jpa.support.AssociationRegistry;
 import com.borjaglez.specrepository.jpa.support.PathResolver;
 import com.borjaglez.specrepository.jpa.support.QueryPlanSpecificationFactory;
@@ -171,6 +172,30 @@ public class SpecificationRepositoryImpl<T, ID extends Serializable>
   }
 
   @Override
+  public List<GroupedRow> findAllGrouped(QueryPlan<T> plan) {
+    if (!plan.hasSelections()) {
+      throw new IllegalStateException(
+          "findAllGrouped requires at least one select() or aggregate selection");
+    }
+    List<String> columns = new ArrayList<>();
+    for (com.borjaglez.specrepository.core.Selection selection : plan.selections()) {
+      if (selection instanceof FieldSelection field) {
+        columns.add(field.field());
+      } else {
+        columns.add(((AggregateSelection) selection).columnName());
+      }
+    }
+    List<?> rawRows = executeProjectedQuery(plan, null);
+    List<GroupedRow> rows = new ArrayList<>(rawRows.size());
+    boolean singleColumn = plan.selections().size() == 1;
+    for (Object raw : rawRows) {
+      Object[] values = singleColumn ? new Object[] {raw} : (Object[]) raw;
+      rows.add(new GroupedRow(columns, values));
+    }
+    return rows;
+  }
+
+  @Override
   public long count(QueryPlan<T> plan) {
     if (!plan.groupBy().isEmpty()) {
       return countGrouped(plan);
@@ -294,47 +319,8 @@ public class SpecificationRepositoryImpl<T, ID extends Serializable>
     }
     AggregateSelection aggregateSelection = (AggregateSelection) selection;
     Path<?> path = pathResolver.resolve(root, registry, aggregateSelection.field(), JoinMode.LEFT);
-    return toAggregateExpression(builder, aggregateSelection, path);
-  }
-
-  @SuppressWarnings({"rawtypes", "unchecked"})
-  private Expression<?> toAggregateExpression(
-      CriteriaBuilder builder, AggregateSelection selection, Path<?> path) {
-    return switch (selection.function()) {
-      case SUM -> builder.sum(asNumberExpression(path, selection));
-      case AVG -> builder.avg(asNumberExpression(path, selection));
-      case MIN -> {
-        if (Number.class.isAssignableFrom(path.getJavaType())) {
-          yield builder.min((Expression<? extends Number>) path);
-        }
-        if (Comparable.class.isAssignableFrom(path.getJavaType())) {
-          yield builder.least((Expression<? extends Comparable>) path);
-        }
-        throw new IllegalArgumentException(
-            "MIN requires a comparable field: " + path.getJavaType());
-      }
-      case MAX -> {
-        if (Number.class.isAssignableFrom(path.getJavaType())) {
-          yield builder.max((Expression<? extends Number>) path);
-        }
-        if (Comparable.class.isAssignableFrom(path.getJavaType())) {
-          yield builder.greatest((Expression<? extends Comparable>) path);
-        }
-        throw new IllegalArgumentException(
-            "MAX requires a comparable field: " + path.getJavaType());
-      }
-      case COUNT -> builder.count(path);
-    };
-  }
-
-  @SuppressWarnings("unchecked")
-  private Expression<? extends Number> asNumberExpression(
-      Path<?> path, AggregateSelection selection) {
-    if (!Number.class.isAssignableFrom(path.getJavaType())) {
-      throw new IllegalArgumentException(
-          selection.function() + " requires a numeric field: " + selection.field());
-    }
-    return (Expression<? extends Number>) path;
+    return AggregateExpressionFactory.create(
+        builder, aggregateSelection.function(), aggregateSelection.field(), path);
   }
 
   private void applySort(

--- a/specification-repository-jpa/src/main/java/com/borjaglez/specrepository/jpa/support/AggregateExpressionFactory.java
+++ b/specification-repository-jpa/src/main/java/com/borjaglez/specrepository/jpa/support/AggregateExpressionFactory.java
@@ -1,0 +1,50 @@
+package com.borjaglez.specrepository.jpa.support;
+
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.Expression;
+import jakarta.persistence.criteria.Path;
+
+import com.borjaglez.specrepository.core.AggregateFunction;
+
+public final class AggregateExpressionFactory {
+  private AggregateExpressionFactory() {}
+
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  public static Expression<?> create(
+      CriteriaBuilder builder, AggregateFunction function, String field, Path<?> path) {
+    return switch (function) {
+      case SUM -> builder.sum(asNumberExpression(function, field, path));
+      case AVG -> builder.avg(asNumberExpression(function, field, path));
+      case MIN -> {
+        if (Number.class.isAssignableFrom(path.getJavaType())) {
+          yield builder.min((Expression<? extends Number>) path);
+        }
+        if (Comparable.class.isAssignableFrom(path.getJavaType())) {
+          yield builder.least((Expression<? extends Comparable>) path);
+        }
+        throw new IllegalArgumentException(
+            "MIN requires a comparable field: " + path.getJavaType());
+      }
+      case MAX -> {
+        if (Number.class.isAssignableFrom(path.getJavaType())) {
+          yield builder.max((Expression<? extends Number>) path);
+        }
+        if (Comparable.class.isAssignableFrom(path.getJavaType())) {
+          yield builder.greatest((Expression<? extends Comparable>) path);
+        }
+        throw new IllegalArgumentException(
+            "MAX requires a comparable field: " + path.getJavaType());
+      }
+      case COUNT -> builder.count(path);
+    };
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Expression<? extends Number> asNumberExpression(
+      AggregateFunction function, String field, Path<?> path) {
+    if (!Number.class.isAssignableFrom(path.getJavaType())) {
+      throw new IllegalArgumentException(function + " requires a numeric field: " + field);
+    }
+    return (Expression<? extends Number>) path;
+  }
+}

--- a/specification-repository-jpa/src/main/java/com/borjaglez/specrepository/jpa/support/AggregateExpressionFactory.java
+++ b/specification-repository-jpa/src/main/java/com/borjaglez/specrepository/jpa/support/AggregateExpressionFactory.java
@@ -9,6 +9,28 @@ import com.borjaglez.specrepository.core.AggregateFunction;
 public final class AggregateExpressionFactory {
   private AggregateExpressionFactory() {}
 
+  public static Class<?> resultType(AggregateFunction function, Class<?> fieldType) {
+    return switch (function) {
+      case COUNT -> Long.class;
+      case AVG -> Double.class;
+      case SUM -> {
+        if (Integer.class == fieldType
+            || int.class == fieldType
+            || Short.class == fieldType
+            || short.class == fieldType
+            || Byte.class == fieldType
+            || byte.class == fieldType) {
+          yield Long.class;
+        }
+        if (Float.class == fieldType || float.class == fieldType) {
+          yield Double.class;
+        }
+        yield fieldType;
+      }
+      case MIN, MAX -> fieldType;
+    };
+  }
+
   @SuppressWarnings({"unchecked", "rawtypes"})
   public static Expression<?> create(
       CriteriaBuilder builder, AggregateFunction function, String field, Path<?> path) {

--- a/specification-repository-jpa/src/main/java/com/borjaglez/specrepository/jpa/support/QueryPlanSpecificationFactory.java
+++ b/specification-repository-jpa/src/main/java/com/borjaglez/specrepository/jpa/support/QueryPlanSpecificationFactory.java
@@ -21,10 +21,13 @@ import com.borjaglez.specrepository.core.AllowedFieldsPolicy;
 import com.borjaglez.specrepository.core.CorrelationMode;
 import com.borjaglez.specrepository.core.CorrelationPair;
 import com.borjaglez.specrepository.core.FetchInstruction;
+import com.borjaglez.specrepository.core.FilterOperator;
 import com.borjaglez.specrepository.core.GroupCondition;
+import com.borjaglez.specrepository.core.HavingCondition;
 import com.borjaglez.specrepository.core.JoinInstruction;
 import com.borjaglez.specrepository.core.JoinMode;
 import com.borjaglez.specrepository.core.LogicalOperator;
+import com.borjaglez.specrepository.core.Operators;
 import com.borjaglez.specrepository.core.PredicateCondition;
 import com.borjaglez.specrepository.core.QueryCondition;
 import com.borjaglez.specrepository.core.QueryPlan;
@@ -65,6 +68,7 @@ public class QueryPlanSpecificationFactory {
       applyJoins(root, registry, plan.joins());
       applyFetches(root, query, registry, plan.fetches());
       applyGrouping(root, query, registry, plan.groupBy());
+      applyHaving(root, query, registry, plan.having(), criteriaBuilder);
 
       if (plan.distinct()) {
         query.distinct(true);
@@ -107,6 +111,92 @@ public class QueryPlanSpecificationFactory {
     fields.forEach(
         field -> expressions.add(pathResolver.resolve(root, registry, field, JoinMode.LEFT)));
     query.groupBy(expressions);
+  }
+
+  private void applyHaving(
+      Root<?> root,
+      CriteriaQuery<?> query,
+      AssociationRegistry registry,
+      List<HavingCondition> havingConditions,
+      CriteriaBuilder criteriaBuilder) {
+    if (havingConditions.isEmpty()) {
+      return;
+    }
+    List<Predicate> predicates = new ArrayList<>();
+    for (HavingCondition condition : havingConditions) {
+      predicates.add(buildHavingPredicate(root, registry, condition, criteriaBuilder));
+    }
+    query.having(criteriaBuilder.and(predicates.toArray(Predicate[]::new)));
+  }
+
+  private Predicate buildHavingPredicate(
+      Root<?> root, AssociationRegistry registry, HavingCondition condition, CriteriaBuilder cb) {
+    Path<?> path = pathResolver.resolve(root, registry, condition.field(), JoinMode.LEFT);
+    Expression<?> aggregate =
+        AggregateExpressionFactory.create(cb, condition.function(), condition.field(), path);
+    return havingPredicate(cb, aggregate, path.getJavaType(), condition);
+  }
+
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  private Predicate havingPredicate(
+      CriteriaBuilder cb, Expression<?> aggregate, Class<?> targetType, HavingCondition condition) {
+    FilterOperator operator = condition.operator();
+    if (Operators.IS_NULL.equals(operator)) {
+      return cb.isNull(aggregate);
+    }
+    if (Operators.IS_NOT_NULL.equals(operator)) {
+      return cb.isNotNull(aggregate);
+    }
+    if (Operators.BETWEEN.equals(operator)) {
+      List<?> bounds = havingRangeValues(condition.value());
+      Object lower = valueConversionService.convert(bounds.get(0), targetType, operator);
+      Object upper = valueConversionService.convert(bounds.get(1), targetType, operator);
+      return cb.between((Expression<Comparable>) aggregate, (Comparable) lower, (Comparable) upper);
+    }
+    if (!isSupportedComparator(operator)) {
+      throw new IllegalArgumentException(
+          "Unsupported operator for having clause: " + operator.value());
+    }
+    Object converted = valueConversionService.convert(condition.value(), targetType, operator);
+    if (Operators.EQUALS.equals(operator)) {
+      return cb.equal(aggregate, converted);
+    }
+    if (Operators.NOT_EQUALS.equals(operator)) {
+      return cb.notEqual(aggregate, converted);
+    }
+    if (Operators.GREATER_THAN.equals(operator)) {
+      return cb.greaterThan((Expression<Comparable>) aggregate, (Comparable) converted);
+    }
+    if (Operators.GREATER_THAN_OR_EQUAL.equals(operator)) {
+      return cb.greaterThanOrEqualTo((Expression<Comparable>) aggregate, (Comparable) converted);
+    }
+    if (Operators.LESS_THAN.equals(operator)) {
+      return cb.lessThan((Expression<Comparable>) aggregate, (Comparable) converted);
+    }
+    return cb.lessThanOrEqualTo((Expression<Comparable>) aggregate, (Comparable) converted);
+  }
+
+  private boolean isSupportedComparator(FilterOperator operator) {
+    return Operators.EQUALS.equals(operator)
+        || Operators.NOT_EQUALS.equals(operator)
+        || Operators.GREATER_THAN.equals(operator)
+        || Operators.GREATER_THAN_OR_EQUAL.equals(operator)
+        || Operators.LESS_THAN.equals(operator)
+        || Operators.LESS_THAN_OR_EQUAL.equals(operator);
+  }
+
+  private List<?> havingRangeValues(Object value) {
+    if (!(value instanceof Iterable<?> iterable)) {
+      throw new IllegalArgumentException("BETWEEN having requires exactly 2 values");
+    }
+    List<?> values =
+        iterable instanceof List<?> list
+            ? list
+            : java.util.stream.StreamSupport.stream(iterable.spliterator(), false).toList();
+    if (values.size() != 2) {
+      throw new IllegalArgumentException("BETWEEN having requires exactly 2 values");
+    }
+    return values;
   }
 
   private Predicate toPredicate(
@@ -284,6 +374,9 @@ public class QueryPlanSpecificationFactory {
       return;
     }
     validateFilterFields(policy, plan.rootCondition());
+    for (HavingCondition having : plan.having()) {
+      policy.validateFilter(having.field());
+    }
     if (plan.sort().isSorted()) {
       plan.sort().forEach(order -> policy.validateSort(order.getProperty()));
     }

--- a/specification-repository-jpa/src/main/java/com/borjaglez/specrepository/jpa/support/QueryPlanSpecificationFactory.java
+++ b/specification-repository-jpa/src/main/java/com/borjaglez/specrepository/jpa/support/QueryPlanSpecificationFactory.java
@@ -134,7 +134,9 @@ public class QueryPlanSpecificationFactory {
     Path<?> path = pathResolver.resolve(root, registry, condition.field(), JoinMode.LEFT);
     Expression<?> aggregate =
         AggregateExpressionFactory.create(cb, condition.function(), condition.field(), path);
-    return havingPredicate(cb, aggregate, path.getJavaType(), condition);
+    Class<?> targetType =
+        AggregateExpressionFactory.resultType(condition.function(), path.getJavaType());
+    return havingPredicate(cb, aggregate, targetType, condition);
   }
 
   @SuppressWarnings({"unchecked", "rawtypes"})

--- a/specification-repository-jpa/src/test/java/com/borjaglez/specrepository/jpa/SpecificationRepositoryImplTest.java
+++ b/specification-repository-jpa/src/test/java/com/borjaglez/specrepository/jpa/SpecificationRepositoryImplTest.java
@@ -71,6 +71,13 @@ class SpecificationRepositoryImplTest {
   }
 
   @Test
+  void shouldRejectFindAllGroupedWhenRepositoryDoesNotSupportIt() {
+    assertThatThrownBy(() -> repository.findAllGrouped(projectedPlan()))
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessage("Grouped queries are not supported by this repository");
+  }
+
+  @Test
   void shouldRejectProjectedFindOneWhenRepositoryDoesNotSupportIt() {
     assertThatThrownBy(() -> repository.findOneProjected(projectedPlan()))
         .isInstanceOf(UnsupportedOperationException.class)

--- a/specification-repository-jpa/src/test/java/com/borjaglez/specrepository/jpa/it/SpecificationRepositoryIntegrationTest.java
+++ b/specification-repository-jpa/src/test/java/com/borjaglez/specrepository/jpa/it/SpecificationRepositoryIntegrationTest.java
@@ -1009,7 +1009,47 @@ class SpecificationRepositoryIntegrationTest {
   }
 
   @Test
-  void shouldFilterWithIsNullHavingForNullableSum() {
+  void shouldFilterWithHavingAgainstAvgAggregate() {
+    // AVG returns Double; the test passes an Integer threshold to verify that the HAVING
+    // value is converted against the aggregate result type, not the underlying field type.
+    List<?> results =
+        repository
+            .query()
+            .where("status", Operators.IS_NOT_NULL, null)
+            .groupBy("status")
+            .sort(Sort.by("status"))
+            .select("status")
+            .avg("age")
+            .having(AggregateFunction.AVG, "age", Operators.GREATER_THAN, 30)
+            .findAll();
+
+    assertThat(results).hasSize(1);
+    assertThat(((Object[]) results.get(0))[0]).isEqualTo("INACTIVE");
+  }
+
+  @Test
+  void shouldFilterWithHavingAgainstCountAggregateUsingIntegerValue() {
+    // COUNT returns Long; passing an int verifies the value is converted to Long via the
+    // aggregate result type rather than the underlying id column type.
+    List<?> results =
+        repository
+            .query()
+            .where("status", Operators.IS_NOT_NULL, null)
+            .groupBy("status")
+            .sort(Sort.by("status"))
+            .select("status")
+            .count("id")
+            .having(AggregateFunction.COUNT, "id", Operators.GREATER_THAN_OR_EQUAL, 2)
+            .findAll();
+
+    assertThat(results).hasSize(1);
+    assertThat(((Object[]) results.get(0))[0]).isEqualTo("ACTIVE");
+  }
+
+  @Test
+  void shouldExecuteIsNullHavingClause() {
+    // COUNT can never be NULL, so this query is expected to return zero rows; the test
+    // exercises the IS_NULL branch of the HAVING translation, not a real filtering use case.
     List<?> results =
         repository
             .query()

--- a/specification-repository-jpa/src/test/java/com/borjaglez/specrepository/jpa/it/SpecificationRepositoryIntegrationTest.java
+++ b/specification-repository-jpa/src/test/java/com/borjaglez/specrepository/jpa/it/SpecificationRepositoryIntegrationTest.java
@@ -21,8 +21,11 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.test.context.ContextConfiguration;
 
+import com.borjaglez.specrepository.core.AggregateFunction;
 import com.borjaglez.specrepository.core.AllowedFieldsPolicy;
 import com.borjaglez.specrepository.core.DisallowedFieldException;
+import com.borjaglez.specrepository.core.FilterOperator;
+import com.borjaglez.specrepository.core.GroupedRow;
 import com.borjaglez.specrepository.core.Operators;
 import com.borjaglez.specrepository.core.QueryPlan;
 import com.borjaglez.specrepository.jpa.SpecificationRepositoryImpl;
@@ -939,6 +942,298 @@ class SpecificationRepositoryIntegrationTest {
                     .findAll())
         .isInstanceOf(DisallowedFieldException.class)
         .hasMessage("Field 'status' is not allowed for sorting");
+  }
+
+  // -- HAVING / multiple aggregates / grouped rows --
+
+  @Test
+  void shouldFilterGroupedResultsWithHavingGreaterThan() {
+    List<?> results =
+        repository
+            .query()
+            .where("status", Operators.IS_NOT_NULL, null)
+            .groupBy("status")
+            .sort(Sort.by("status"))
+            .select("status")
+            .count("id")
+            .having(AggregateFunction.COUNT, "id", Operators.GREATER_THAN, 1L)
+            .findAll();
+
+    assertThat(results).hasSize(1);
+    assertThat((Object[]) results.get(0)).containsExactly("ACTIVE", 2L);
+  }
+
+  @Test
+  void shouldFilterWithMultipleHavingPredicatesAndedTogether() {
+    List<?> results =
+        repository
+            .query()
+            .where("status", Operators.IS_NOT_NULL, null)
+            .groupBy("status")
+            .sort(Sort.by("status"))
+            .select("status")
+            .sum("age")
+            .count("id")
+            .having(AggregateFunction.SUM, "age", Operators.GREATER_THAN_OR_EQUAL, 41)
+            .having(AggregateFunction.COUNT, "id", Operators.LESS_THAN_OR_EQUAL, 1L)
+            .findAll();
+
+    assertThat(results).hasSize(1);
+    assertThat((Object[]) results.get(0)).containsExactly("INACTIVE", 41, 1L);
+  }
+
+  @Test
+  void shouldSupportEveryHavingComparator() {
+    assertHavingMatch(Operators.EQUALS, 2L, "ACTIVE");
+    assertHavingMatch(Operators.NOT_EQUALS, 2L, "INACTIVE");
+    assertHavingMatch(Operators.LESS_THAN, 2L, "INACTIVE");
+    assertHavingMatch(Operators.LESS_THAN_OR_EQUAL, 1L, "INACTIVE");
+    assertHavingMatch(Operators.IS_NOT_NULL, null, "ACTIVE", "INACTIVE");
+  }
+
+  @Test
+  void shouldFilterWithBetweenHavingClause() {
+    List<?> results =
+        repository
+            .query()
+            .where("status", Operators.IS_NOT_NULL, null)
+            .groupBy("status")
+            .sort(Sort.by("status"))
+            .select("status")
+            .count("id")
+            .having(AggregateFunction.COUNT, "id", Operators.BETWEEN, java.util.List.of(1L, 1L))
+            .findAll();
+
+    assertThat(results).hasSize(1);
+    assertThat((Object[]) results.get(0)).containsExactly("INACTIVE", 1L);
+  }
+
+  @Test
+  void shouldFilterWithIsNullHavingForNullableSum() {
+    List<?> results =
+        repository
+            .query()
+            .groupBy("status")
+            .sort(Sort.by("status"))
+            .select("status")
+            .count("id")
+            .having(AggregateFunction.COUNT, "id", Operators.IS_NULL, null)
+            .findAll();
+
+    assertThat(results).isEmpty();
+  }
+
+  @Test
+  void shouldFilterWithBetweenHavingUsingNonListIterable() {
+    java.util.LinkedHashSet<Long> bounds = new java.util.LinkedHashSet<>();
+    bounds.add(1L);
+    bounds.add(2L);
+    Iterable<Long> iterable = () -> bounds.iterator();
+    List<?> results =
+        repository
+            .query()
+            .where("status", Operators.IS_NOT_NULL, null)
+            .groupBy("status")
+            .sort(Sort.by("status"))
+            .select("status")
+            .count("id")
+            .having(AggregateFunction.COUNT, "id", Operators.BETWEEN, iterable)
+            .findAll();
+
+    assertThat(results).hasSize(2);
+  }
+
+  @Test
+  void shouldRejectBetweenHavingWithWrongValueShape() {
+    assertThatThrownBy(
+            () ->
+                repository
+                    .query()
+                    .groupBy("status")
+                    .count("id")
+                    .having(AggregateFunction.COUNT, "id", Operators.BETWEEN, "not a list")
+                    .findAll())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("BETWEEN having requires exactly 2 values");
+  }
+
+  @Test
+  void shouldRejectBetweenHavingWithWrongArity() {
+    assertThatThrownBy(
+            () ->
+                repository
+                    .query()
+                    .groupBy("status")
+                    .count("id")
+                    .having(
+                        AggregateFunction.COUNT,
+                        "id",
+                        Operators.BETWEEN,
+                        java.util.List.of(1L, 2L, 3L))
+                    .findAll())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("BETWEEN having requires exactly 2 values");
+  }
+
+  @Test
+  void shouldRejectUnsupportedHavingOperator() {
+    assertThatThrownBy(
+            () ->
+                repository
+                    .query()
+                    .groupBy("status")
+                    .count("id")
+                    .having(AggregateFunction.COUNT, "id", Operators.CONTAINS, "x")
+                    .findAll())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Unsupported operator for having clause: contains");
+  }
+
+  @Test
+  void shouldRejectHavingWithCustomOperator() {
+    assertThatThrownBy(
+            () ->
+                repository
+                    .query()
+                    .groupBy("status")
+                    .count("id")
+                    .having(AggregateFunction.COUNT, "id", FilterOperator.of("foobar"), 1L)
+                    .findAll())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Unsupported operator for having clause: foobar");
+  }
+
+  @Test
+  void shouldAcceptAllowedHavingFieldUnderPolicy() {
+    AllowedFieldsPolicy policy = AllowedFieldsPolicy.of(Set.of("status", "id"), Set.of("status"));
+
+    List<?> results =
+        repository
+            .query()
+            .allowedFields(policy)
+            .where("status", Operators.IS_NOT_NULL, null)
+            .groupBy("status")
+            .sort(Sort.by("status"))
+            .select("status")
+            .count("id")
+            .having(AggregateFunction.COUNT, "id", Operators.GREATER_THAN_OR_EQUAL, 1L)
+            .findAll();
+
+    assertThat(results).hasSize(2);
+  }
+
+  @Test
+  void shouldValidateHavingFieldAgainstAllowedFieldsPolicy() {
+    AllowedFieldsPolicy policy = AllowedFieldsPolicy.of(Set.of("status"), Set.of("status"));
+
+    assertThatThrownBy(
+            () ->
+                repository
+                    .query()
+                    .allowedFields(policy)
+                    .groupBy("status")
+                    .count("id")
+                    .having(AggregateFunction.COUNT, "id", Operators.GREATER_THAN, 1L)
+                    .findAll())
+        .isInstanceOf(DisallowedFieldException.class)
+        .hasMessage("Field 'id' is not allowed for filtering");
+  }
+
+  @Test
+  void shouldSupportMultipleAggregatesInOneQuery() {
+    List<GroupedRow> rows =
+        repository
+            .query()
+            .where("status", Operators.IS_NOT_NULL, null)
+            .groupBy("status")
+            .sort(Sort.by("status"))
+            .select("status")
+            .sumAs("totalAge", "age")
+            .avgAs("averageAge", "age")
+            .countAs("customers", "id")
+            .minAs("youngest", "age")
+            .maxAs("oldest", "age")
+            .findAllGrouped();
+
+    assertThat(rows).hasSize(2);
+    GroupedRow active = rows.get(0);
+    assertThat(active.get("status")).isEqualTo("ACTIVE");
+    assertThat(active.get("totalAge")).isEqualTo(57);
+    assertThat(((Number) active.get("averageAge")).doubleValue()).isEqualTo(28.5d);
+    assertThat(active.get("customers")).isEqualTo(2L);
+    assertThat(active.get("youngest")).isEqualTo(25);
+    assertThat(active.get("oldest")).isEqualTo(32);
+  }
+
+  @Test
+  void shouldReturnSingleColumnGroupedRow() {
+    List<GroupedRow> rows =
+        repository
+            .query()
+            .where("status", Operators.IS_NOT_NULL, null)
+            .groupBy("status")
+            .sort(Sort.by("status"))
+            .countAs("customers", "id")
+            .findAllGrouped();
+
+    assertThat(rows).hasSize(2);
+    assertThat(rows.get(0).columns()).containsExactly("customers");
+    assertThat(rows.get(0).get("customers")).isEqualTo(2L);
+    assertThat(rows.get(1).get(0)).isEqualTo(1L);
+  }
+
+  @Test
+  void shouldFallbackToDerivedColumnNameWhenAliasMissing() {
+    List<GroupedRow> rows =
+        repository
+            .query()
+            .where("status", Operators.IS_NOT_NULL, null)
+            .groupBy("status")
+            .sort(Sort.by("status"))
+            .select("status")
+            .count("id")
+            .findAllGrouped();
+
+    assertThat(rows.get(0).columns()).containsExactly("status", "COUNT_id");
+    assertThat(rows.get(0).get("COUNT_id")).isEqualTo(2L);
+  }
+
+  @Test
+  void findAllGroupedShouldRequireSelections() {
+    assertThatThrownBy(() -> repository.query().findAllGrouped())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("findAllGrouped requires");
+  }
+
+  @Test
+  void havingWithoutGroupByShouldFailFastInBuilder() {
+    assertThatThrownBy(
+            () ->
+                repository
+                    .query()
+                    .sum("age")
+                    .having(AggregateFunction.SUM, "age", Operators.GREATER_THAN, 1)
+                    .findAll())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("having requires at least one groupBy field");
+  }
+
+  private void assertHavingMatch(
+      FilterOperator operator, Object value, String... expectedStatuses) {
+    List<?> rows =
+        repository
+            .query()
+            .where("status", Operators.IS_NOT_NULL, null)
+            .groupBy("status")
+            .sort(Sort.by("status"))
+            .select("status")
+            .count("id")
+            .having(AggregateFunction.COUNT, "id", operator, value)
+            .findAll();
+
+    assertThat(rows)
+        .extracting(row -> ((Object[]) row)[0])
+        .containsExactly((Object[]) expectedStatuses);
   }
 
   @Configuration(proxyBeanMethods = false)

--- a/specification-repository-jpa/src/test/java/com/borjaglez/specrepository/jpa/support/AggregateExpressionFactoryTest.java
+++ b/specification-repository-jpa/src/test/java/com/borjaglez/specrepository/jpa/support/AggregateExpressionFactoryTest.java
@@ -1,0 +1,74 @@
+package com.borjaglez.specrepository.jpa.support;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.time.LocalDate;
+
+import org.junit.jupiter.api.Test;
+
+import com.borjaglez.specrepository.core.AggregateFunction;
+
+class AggregateExpressionFactoryTest {
+
+  @Test
+  void countAlwaysResolvesToLong() {
+    assertThat(AggregateExpressionFactory.resultType(AggregateFunction.COUNT, String.class))
+        .isEqualTo(Long.class);
+    assertThat(AggregateExpressionFactory.resultType(AggregateFunction.COUNT, Integer.class))
+        .isEqualTo(Long.class);
+  }
+
+  @Test
+  void avgAlwaysResolvesToDouble() {
+    assertThat(AggregateExpressionFactory.resultType(AggregateFunction.AVG, Integer.class))
+        .isEqualTo(Double.class);
+    assertThat(AggregateExpressionFactory.resultType(AggregateFunction.AVG, BigDecimal.class))
+        .isEqualTo(Double.class);
+  }
+
+  @Test
+  void sumWidensIntegralFieldsToLong() {
+    assertThat(AggregateExpressionFactory.resultType(AggregateFunction.SUM, Integer.class))
+        .isEqualTo(Long.class);
+    assertThat(AggregateExpressionFactory.resultType(AggregateFunction.SUM, int.class))
+        .isEqualTo(Long.class);
+    assertThat(AggregateExpressionFactory.resultType(AggregateFunction.SUM, Short.class))
+        .isEqualTo(Long.class);
+    assertThat(AggregateExpressionFactory.resultType(AggregateFunction.SUM, short.class))
+        .isEqualTo(Long.class);
+    assertThat(AggregateExpressionFactory.resultType(AggregateFunction.SUM, Byte.class))
+        .isEqualTo(Long.class);
+    assertThat(AggregateExpressionFactory.resultType(AggregateFunction.SUM, byte.class))
+        .isEqualTo(Long.class);
+  }
+
+  @Test
+  void sumWidensFloatToDouble() {
+    assertThat(AggregateExpressionFactory.resultType(AggregateFunction.SUM, Float.class))
+        .isEqualTo(Double.class);
+    assertThat(AggregateExpressionFactory.resultType(AggregateFunction.SUM, float.class))
+        .isEqualTo(Double.class);
+  }
+
+  @Test
+  void sumKeepsOtherNumericTypes() {
+    assertThat(AggregateExpressionFactory.resultType(AggregateFunction.SUM, Long.class))
+        .isEqualTo(Long.class);
+    assertThat(AggregateExpressionFactory.resultType(AggregateFunction.SUM, Double.class))
+        .isEqualTo(Double.class);
+    assertThat(AggregateExpressionFactory.resultType(AggregateFunction.SUM, BigDecimal.class))
+        .isEqualTo(BigDecimal.class);
+    assertThat(AggregateExpressionFactory.resultType(AggregateFunction.SUM, BigInteger.class))
+        .isEqualTo(BigInteger.class);
+  }
+
+  @Test
+  void minAndMaxKeepFieldType() {
+    assertThat(AggregateExpressionFactory.resultType(AggregateFunction.MIN, LocalDate.class))
+        .isEqualTo(LocalDate.class);
+    assertThat(AggregateExpressionFactory.resultType(AggregateFunction.MAX, String.class))
+        .isEqualTo(String.class);
+  }
+}


### PR DESCRIPTION
Closes #25.

## Summary
- Adds `having(...)` to the query DSL for filtering grouped results, plus optional aliases on aggregate selections (`sumAs`, `avgAs`, `minAs`, `maxAs`, `countAs`, `aggregate(fn, field, alias)`).
- Adds a `GroupedRow` value object and a `findAllGrouped()` terminal for structured analytical results with lookup by index or column/alias name.
- Multiple aggregates per query were already supported; this PR adds explicit tests covering it and documents the pattern.
- Extracts aggregate expression building into `AggregateExpressionFactory`, reused by both projection selection and HAVING translation.
- New `docs/reporting.md` guide and a HAVING + `GroupedRow` example wired into `boot3-demo` (`/api/products/reporting/status-revenue-above`).

## Design notes
- HAVING supports the comparators that map cleanly onto aggregate expressions: `EQUALS`, `NOT_EQUALS`, `GT`, `GTE`, `LT`, `LTE`, `BETWEEN`, `IS_NULL`, `IS_NOT_NULL`. Pattern / collection operators are rejected with `IllegalArgumentException`.
- Multiple `having(...)` calls are AND-combined. Nested AND/OR groups inside HAVING are intentionally out of scope for now (smallest API surface that satisfies #25, easy to extend later).
- `having(...)` without `groupBy(...)` is rejected at `QueryPlanBuilder.build()` time.
- HAVING fields are validated against `AllowedFieldsPolicy.validateFilter`, so HAVING can be safely exposed via the existing whitelist mechanism.
- `QueryPlan` keeps both legacy constructors so existing direct callers continue to compile and link.

## Test plan
- [x] `./gradlew quality` passes locally (tests + 100% line/branch coverage + spotless).
- [x] New core unit tests for `AggregateSelection`, `HavingCondition`, `GroupedRow`, and the `having` builder paths.
- [x] New JPA integration tests covering: HAVING with every supported operator, BETWEEN with `List` and non-`List` `Iterable`, multiple aggregates with aliases, `findAllGrouped()` lookup by alias and by derived column name, allowed-fields validation for HAVING fields, and rejection paths (unsupported operator, malformed BETWEEN, having without groupBy).
- [x] `boot3-demo` compiles with the new endpoint.