### PR TITLE
chore: migrate Maven Central group ID to com.borjaglez.specrepository (#33)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Breaking**: Maven Central group ID migrated from `com.borjaglez` to `com.borjaglez.specrepository`. Consumers must update their dependency coordinates — artifact IDs remain unchanged (#33).
+
 ### Added
 - DSL support for `EXISTS` / `NOT EXISTS` and `IN (subquery)` / `NOT IN (subquery)` with association-based or entity-based correlation (#23)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # spring-boot-specification-repository
 
-[![Maven Central](https://img.shields.io/maven-central/v/com.borjaglez/specification-repository-core)](https://central.sonatype.com/artifact/com.borjaglez/specification-repository-core)
+[![Maven Central](https://img.shields.io/maven-central/v/com.borjaglez.specrepository/specification-repository-core)](https://central.sonatype.com/artifact/com.borjaglez.specrepository/specification-repository-core)
 [![CI](https://github.com/borja-glez/spring-boot-specification-repository/actions/workflows/ci.yml/badge.svg)](https://github.com/borja-glez/spring-boot-specification-repository/actions/workflows/ci.yml)
 [![License](https://img.shields.io/github/license/borja-glez/spring-boot-specification-repository)](LICENSE)
 ![Java 21+](https://img.shields.io/badge/Java-21%2B-blue)
@@ -42,14 +42,14 @@ The `specification-repository-core` and `specification-repository-jpa` modules s
 **Gradle**
 
 ```kotlin
-implementation("com.borjaglez:specification-repository-boot3-starter:0.1.0")
+implementation("com.borjaglez.specrepository:specification-repository-boot3-starter:0.1.0")
 ```
 
 **Maven**
 
 ```xml
 <dependency>
-    <groupId>com.borjaglez</groupId>
+    <groupId>com.borjaglez.specrepository</groupId>
     <artifactId>specification-repository-boot3-starter</artifactId>
     <version>0.1.0</version>
 </dependency>
@@ -60,14 +60,14 @@ implementation("com.borjaglez:specification-repository-boot3-starter:0.1.0")
 **Gradle**
 
 ```kotlin
-implementation("com.borjaglez:specification-repository-boot4-starter:0.1.0")
+implementation("com.borjaglez.specrepository:specification-repository-boot4-starter:0.1.0")
 ```
 
 **Maven**
 
 ```xml
 <dependency>
-    <groupId>com.borjaglez</groupId>
+    <groupId>com.borjaglez.specrepository</groupId>
     <artifactId>specification-repository-boot4-starter</artifactId>
     <version>0.1.0</version>
 </dependency>
@@ -686,7 +686,7 @@ classpath. Works with both Spring Boot 3 and Spring Boot 4.
 **Gradle**
 
 ```kotlin
-implementation("com.borjaglez:specification-repository-http:0.1.0")
+implementation("com.borjaglez.specrepository:specification-repository-http:0.1.0")
 ```
 
 ### Query Parameter Contract

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -1,15 +1,16 @@
 # Publishing
 
-Artifacts are published under group ID `com.borjaglez` and configured for OSSRH / Maven Central publication.
+Artifacts are published under group ID `com.borjaglez.specrepository` and configured for OSSRH / Maven Central publication.
 
 ## Published Modules
 
 | Module | Artifact |
 |---|---|
-| `specification-repository-core` | `com.borjaglez:specification-repository-core` |
-| `specification-repository-jpa` | `com.borjaglez:specification-repository-jpa` |
-| `specification-repository-boot3-starter` | `com.borjaglez:specification-repository-boot3-starter` |
-| `specification-repository-boot4-starter` | `com.borjaglez:specification-repository-boot4-starter` |
+| `specification-repository-core` | `com.borjaglez.specrepository:specification-repository-core` |
+| `specification-repository-jpa` | `com.borjaglez.specrepository:specification-repository-jpa` |
+| `specification-repository-boot3-starter` | `com.borjaglez.specrepository:specification-repository-boot3-starter` |
+| `specification-repository-boot4-starter` | `com.borjaglez.specrepository:specification-repository-boot4-starter` |
+| `specification-repository-http` | `com.borjaglez.specrepository:specification-repository-http` |
 
 The `specification-repository-test-support` module and all `examples/*` modules are NOT published.
 
@@ -17,7 +18,7 @@ The `specification-repository-test-support` module and all `examples/*` modules 
 
 ### 1. Sonatype Central Portal Account
 
-Create an account at [central.sonatype.org](https://central.sonatype.org/) and verify ownership of the `com.borjaglez` namespace.
+Create an account at [central.sonatype.org](https://central.sonatype.org/) and verify ownership of the `com.borjaglez` namespace. The `com.borjaglez.specrepository` sub-namespace is inherited from the verified parent — no separate verification required.
 
 ### 2. Generate a GPG Signing Key
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-group=com.borjaglez
+group=com.borjaglez.specrepository
 version=0.1.1-SNAPSHOT
 description=Extensible Spring Data JPA specification repository library with fluent DSL and native-friendly architecture
 org.gradle.caching=true


### PR DESCRIPTION
## Summary

- Migrates published coordinates from `com.borjaglez` to `com.borjaglez.specrepository`, aligned with the base Java package.
- Artifact IDs are intentionally **unchanged** to avoid generic-name collisions in dependency trees.
- No Java package rename, no `build-logic/` changes — the publish convention plugin does not hardcode the group.

## Changes

- `gradle.properties`: `group=com.borjaglez.specrepository`
- `README.md`: Maven Central badge + Gradle/Maven dependency snippets (Boot 3, Boot 4, HTTP)
- `docs/publishing.md`: artifact table, namespace verification note, added `specification-repository-http` row
- `CHANGELOG.md`: `### Changed` entry under `[Unreleased]` flagging the breaking coordinate change

## Versioning

Project is still pre-1.0 (`0.1.1-SNAPSHOT`, last pre-release `0.1.0-rc.1`). Per SemVer, no forced major bump — the next release (`0.2.0` or first stable `1.0.0`) carries the new coordinates. The CHANGELOG still flags it as breaking for consumers of the pre-releases.

## Test plan

- [ ] `./gradlew quality` passes locally
- [ ] `./gradlew publishToMavenLocal` produces artifacts under `~/.m2/repository/com/borjaglez/specrepository/`
- [ ] Spot-check a published POM for the new `<groupId>`
- [ ] Verify `com.borjaglez.specrepository` sub-namespace is accepted on Central Portal on next snapshot publish

Closes #33